### PR TITLE
added subroutine `chk_poisson`

### DIFF
--- a/src/debug.f90
+++ b/src/debug.f90
@@ -79,4 +79,39 @@ module mod_debug
     !$acc end data
     call MPI_ALLREDUCE(MPI_IN_PLACE,diffmax,1,MPI_REAL_RP,MPI_MAX,MPI_COMM_WORLD,ierr)
   end subroutine chk_helmholtz
+  subroutine chk_poisson(lo,hi,dli,dzci,dzfi,fp,fpp,diffmax)
+    !
+    ! this subroutine checks if the Poisson equation is correctly solved;
+    ! the inputs should be downcasted to precision `gp` to ensure proper
+    ! testing when single precision is used
+    !
+    implicit none
+    integer , intent(in), dimension(3) :: lo,hi
+    real(gp), intent(in), dimension(2) :: dli
+    real(gp), intent(in), dimension(lo(3)-1:) :: dzci,dzfi
+    real(gp), intent(in), dimension(lo(1)-1:,lo(2)-1:,lo(3)-1:) :: fp,fpp
+    real(gp), intent(out) :: diffmax
+    real(gp) :: val
+    integer :: i,j,k
+    real(gp) :: dxi,dyi
+    dxi = dli(1); dyi = dli(2)
+    diffmax = 0.
+    !$acc wait
+    !$acc data copy(diffmax)
+    !$acc parallel loop collapse(3) default(present) private(val) reduction(max:diffmax)
+    do k=lo(3),hi(3)
+      do j=lo(2),hi(2)
+        do i=lo(1),hi(1)
+          val = (fpp(i+1,j,k)-2.*fpp(i,j,k)+fpp(i-1,j,k))*(dxi**2) + &
+                (fpp(i,j+1,k)-2.*fpp(i,j,k)+fpp(i,j-1,k))*(dyi**2) + &
+               ((fpp(i,j,k+1)-fpp(i,j,k  ))*dzci(k ) - &
+                (fpp(i,j,k  )-fpp(i,j,k-1))*dzci(k-1))*dzfi(k)
+          diffmax = max(diffmax,abs(val-fp(i,j,k)))
+          !if(abs(val-fp(i,j,k)) > 1.e-8) print*, 'Large difference : ', val-fp(i,j,k),i,j,k
+        end do
+      end do
+    end do
+    !$acc end data
+    call MPI_ALLREDUCE(MPI_IN_PLACE,diffmax,1,MPI_REAL_RP,MPI_MAX,MPI_COMM_WORLD,ierr)
+  end subroutine chk_poisson
 end module mod_debug


### PR DESCRIPTION
Added a subroutine to directly test the correctness of the Poisson solver solution, as an alternative to the current check of a correct Helmholtz decomposition (a pressure projection for a random velocity field into divergence-free space). Unused for now.