### PR TITLE
added cpp macro to set the default value of `eps_??` to zero

### DIFF
--- a/src/param.f90
+++ b/src/param.f90
@@ -13,9 +13,15 @@ public
 ! parameters
 !
 real(rp), parameter :: pi = acos(-1._rp)
+#if !defined(_EPS_EXACT_ZERO) /* recommended */
 real(sp), parameter :: eps_sp = epsilon(1._sp)
 real(dp), parameter :: eps_dp = epsilon(1._dp)
 real(rp), parameter :: eps_rp = epsilon(1._rp)
+#else
+real(sp), parameter :: eps_sp = 0._sp
+real(dp), parameter :: eps_dp = 0._dp
+real(rp), parameter :: eps_rp = 0._rp
+#endif
 real(gp), parameter :: small = epsilon(1._gp)*10**(precision(1._gp)/2)
 character(len=100), parameter :: datadir = 'data/'
 real(rp), parameter, dimension(2,3) :: rkcoeff = reshape([32._rp/60._rp,  0._rp        , &


### PR DESCRIPTION
not necessary in production runs, but may be useful for analyzes of the numerical method