### PR TITLE
Revert "ssh better for submodules than https"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "dependencies/cuDecomp"]
 	path = dependencies/cuDecomp
-	url = git@github.com:NVIDIA/cuDecomp.git
+	url = https://github.com/NVIDIA/cuDecomp
 [submodule "dependencies/2decomp-fft"]
 	path = dependencies/2decomp-fft
-	url = git@github.com:CaNS-World/2decomp-fft.git
+	url = https://github.com/CaNS-World/2decomp-fft


### PR DESCRIPTION
This reverts commit 9a284ff42d0a7339290e1fcd372dba46e156d064.

Some users face issues when cloning using ssh.