### PR TITLE
changed input files to take `visci`, the inverse viscosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ P. Costa. *A FFT-based finite-difference solver for massively-parallel direct nu
 
 ## News
 
+**[03/02/2023]:** The input file `dns.in` has been simplified to avoid a common source of confusion. Instead of prescribing `uref`, `lref`, and `rey` (reference velocity and length scales, and Reynolds number) to calculate the fluid viscosity as `visc = uref*lref/rey`, we directly prescrive the inverse of the viscosity, `visci` (`visc = visci**(-1)`), so all inputs are dimensional (see the updated [`docs/INFO_INPUT.md`](docs/INFO_INPUT.md) file). Note that `visci` has the same value as the flow Reynolds number for all files under `examples`, as `uref` and `lref` were always equal to `1`. *This change is backwards-incompatible - former input files should be updated from [v2.2.0](https://github.com/CaNS-World/CaNS/tree/v2.2.0) onward!*
+
 **[24/10/2022]:** Option `SINGLE_PRECISION_POISSON` has been removed from the `main` branch. While solving the Poisson in lower precision equation yields excellent results for many benchmarks, several of these cases also perform well when the whole calculation is performed in lower precision (see https://github.com/CaNS-World/CaNS/pull/42). Since this mode introduces significant complexity, it will be removed from the main branch for now in favor of a more readable code, a decision that can be reconsidered in the future. This option can still be explored in [v2.0.1](https://github.com/CaNS-World/CaNS/tree/v2.0.1), and is valuable for, e.g., setups with high Reynolds numbers and/or with extremely fine grids.
 
 ### _Major Update:_ [`CaNS 2.0`](docs/CaNS-2.0.md) _is finally out!_ :tada:

--- a/docs/INFO_INPUT.md
+++ b/docs/INFO_INPUT.md
@@ -7,7 +7,7 @@ Consider the following input file as example (corresponds to a turbulent plane c
 6. 3. 1.                 ! lx, ly, lz
 0.                       ! gr
 .95 1.0e5                ! cfl, dtmin
-1. 1. 5640.              ! uref, lref, rey
+5640.                    ! visci
 poi                      ! inivel
 T                        ! is_wallturb
 100000 100. 0.1          ! nstep, time_max, tw_max
@@ -57,12 +57,10 @@ The time step is set to be equal to `min(cfl*dtmax,dtmin)`, i.e. the minimum val
 ---
 
 ~~~
-1. 1. 5640.              ! uref, lref, rey
+5640.                    ! visci
 ~~~
 
-This line defines the flow governing parameters.
-
-`uref`, `lref` and `rey` are a reference **velocity scale**, **length scale**, and **Reynolds number** defining the problem. The fluid kinematic viscosity is computed form these quantities.
+This line defines the inverse of the fluid viscosity, `visci`, meaning that the viscosity is `visc = visci**(-1)`. Note that, for a setup defined with unit reference length and velocity scales, `visci` has the same value as the flow Reynolds number.
 
 ---
 

--- a/examples/_manuscript_lid_driven_cavity/dns.in
+++ b/examples/_manuscript_lid_driven_cavity/dns.in
@@ -2,7 +2,7 @@
 1. 1. 1.                 ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 1000.              ! uref, lref, rey
+1000.                    ! visci
 zer                      ! inivel
 F                        ! is_wallturb
 10000 100. 0.1           ! nstep,time_max,tw_max

--- a/examples/_manuscript_taylor_green_vortex/dns.in
+++ b/examples/_manuscript_taylor_green_vortex/dns.in
@@ -2,7 +2,7 @@
 6.2831853071795 6.283185307179586 6.283185307179586 ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 1600.              ! uref, lref, rey
+1600.                    ! visci
 tgv                      ! inivel
 F                        ! is_wallturb
 100000 100. 0.1          ! nstep,time_max,tw_max

--- a/examples/_manuscript_turbulent_channel/dns.in
+++ b/examples/_manuscript_turbulent_channel/dns.in
@@ -2,7 +2,7 @@
 6. 3. 1.                 ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 5640.              ! uref, lref, rey
+5640.                    ! visci
 poi                      ! inivel
 T                        ! is_wallturb
 100000 100. 0.1          ! nstep,time_max,tw_max

--- a/examples/_manuscript_turbulent_duct/dns.in
+++ b/examples/_manuscript_turbulent_duct/dns.in
@@ -2,7 +2,7 @@
 10. 1. 1.                ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 4410.              ! uref, lref, rey
+4410.                    ! visci
 poi                      ! inivel
 T                        ! is_wallturb
 100000 100. 0.1          ! nstep,time_max,tw_max

--- a/examples/closed_box/dns.in
+++ b/examples/closed_box/dns.in
@@ -2,7 +2,7 @@
 1. 1. 1.                 ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 1000.              ! uref, lref, rey
+1000.                    ! visci
 zer                      ! inivel
 F                        ! is_wallturb
 100000 100. 0.1          ! nstep,time_max,tw_max

--- a/examples/couette/dns.in
+++ b/examples/couette/dns.in
@@ -2,7 +2,7 @@
 1. 1.5 1.                ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 1000.              ! uref, lref, rey
+1000.                    ! visci
 cou                      ! inivel
 F                        ! is_wallturb
 20000 100. 0.1           ! nstep,time_max,tw_max

--- a/examples/developing_channel/dns.in
+++ b/examples/developing_channel/dns.in
@@ -2,7 +2,7 @@
 1. 1.5 1.                ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 1000.              ! uref, lref, rey
+1000.                    ! visci
 zer                      ! inivel
 F                        ! is_wallturb
 20000 100. 0.1           ! nstep,time_max,tw_max

--- a/examples/developing_duct/dns.in
+++ b/examples/developing_duct/dns.in
@@ -2,7 +2,7 @@
 1. 1.5 1.                ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 1000.              ! uref, lref, rey
+1000.                    ! visci
 zer                      ! inivel
 F                        ! is_wallturb
 20000 100. 0.1           ! nstep,time_max,tw_max

--- a/examples/half_channel/dns.in
+++ b/examples/half_channel/dns.in
@@ -2,7 +2,7 @@
 1. 1.5 1.                ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 1000.              ! uref, lref, rey
+1000.                    ! visci
 hcl                      ! inivel
 F                        ! is_wallturb
 20000 100. 0.1           ! nstep,time_max,tw_max

--- a/examples/lid_driven_cavity/dns.in
+++ b/examples/lid_driven_cavity/dns.in
@@ -2,7 +2,7 @@
 1. 1. 1.                 ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 1000.              ! uref, lref, rey
+1000.                    ! visci
 zer                      ! inivel
 F                        ! is_wallturb
 20000 100. 0.1           ! nstep,time_max,tw_max

--- a/examples/periodic_channel/dns.in
+++ b/examples/periodic_channel/dns.in
@@ -2,7 +2,7 @@
 3. 1.5 1.                ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 1000.              ! uref, lref, rey
+1000.                    ! visci
 log                      ! inivel
 F                        ! is_wallturb
 100000 100. 0.1          ! nstep,time_max,tw_max

--- a/examples/periodic_duct/dns.in
+++ b/examples/periodic_duct/dns.in
@@ -2,7 +2,7 @@
 3. 1.5 1.                ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 1000.              ! uref, lref, rey
+1000.                    ! visci
 log                      ! inivel
 F                        ! is_wallturb
 100000 100. 0.1          ! nstep,time_max,tw_max

--- a/examples/taylor_green_vortex_2d/dns.in
+++ b/examples/taylor_green_vortex_2d/dns.in
@@ -2,7 +2,7 @@
 6.2831853071795 6.283185307179586 0.125 ! lx, ly, lz
 0.                      ! gr
 .95 0.1                 ! cfl, dtmin
-1. 1. 100.              ! uref, lref, rey
+100.                    ! visci
 tgw                     ! inivel
 F                       ! is_wallturb
 100000 100. 0.1         ! nstep,time_max,tw_max

--- a/examples/temporal_boundary_layer/dns.in
+++ b/examples/temporal_boundary_layer/dns.in
@@ -2,7 +2,7 @@
 40. 20. 72.                ! lx, ly, lz
 4.                         ! gr
 .95 1.e5                   ! cfl, dtmin
-1. 1. 500.                 ! uref, lref, rey
+500.                       ! visci
 tbl                        ! inivel
 F                          ! is_wallturb
 5000 100. 0.1              ! nstep,time_max,tw_max

--- a/examples/triperiodic/dns.in
+++ b/examples/triperiodic/dns.in
@@ -2,7 +2,7 @@
 1. 1. 1.                 ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 1000.              ! uref, lref, rey
+1000.                    ! visci
 zer                      ! inivel
 F                        ! is_wallturb
 10000 100. 0.1           ! nstep,time_max,tw_max

--- a/examples/turbulent_channel_constant_pressure_gradient/dns.in
+++ b/examples/turbulent_channel_constant_pressure_gradient/dns.in
@@ -2,7 +2,7 @@
 12. 6. 2.                ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 180.               ! uref, lref, rey
+180.                     ! visci
 pdc                      ! inivel
 T                        ! is_wallturb
 100000 100. 0.1          ! nstep,time_max,tw_max

--- a/examples/turbulent_channel_convective_reference_frame/dns.in
+++ b/examples/turbulent_channel_convective_reference_frame/dns.in
@@ -2,7 +2,7 @@
 6. 3. 1.                 ! lx, ly, lz
 0.                       ! gr
 .95 1.e5                 ! cfl, dtmin
-1. 1. 5640.              ! uref, lref, rey
+5640.                    ! visci
 iop                      ! inivel
 T                        ! is_wallturb
 100000 100. 0.1          ! nstep,time_max,tw_max

--- a/src/initflow.f90
+++ b/src/initflow.f90
@@ -7,29 +7,30 @@
 module mod_initflow
   use mpi
   use mod_common_mpi, only: ierr,myid
-  use mod_param     , only: pi,dx,dy,dz,lx,ly,lz,uref,lref,is_wallturb,bforce
+  use mod_param     , only: pi,dx,dy,dz,lx,ly,lz,is_wallturb,is_forced,velf,bforce,bcvel
   use mod_types
   implicit none
   private
   public initflow,add_noise
   contains
-  subroutine initflow(inivel,ng,lo,zclzi,dzclzi,dzflzi,visc,u,v,w,p)
+  subroutine initflow(inivel,ng,lo,zc,dzc,dzf,visc,u,v,w,p)
     !
     ! computes initial conditions for the velocity field
     !
     implicit none
     character(len=3), intent(in) :: inivel
     integer , intent(in), dimension(3) :: ng,lo
-    real(rp), intent(in), dimension(0:) :: zclzi,dzclzi,dzflzi
+    real(rp), intent(in), dimension(0:) :: zc,dzc,dzf
     real(rp), intent(in) :: visc
     real(rp), dimension(0:,0:,0:), intent(out) :: u,v,w,p
     real(rp), allocatable, dimension(:) :: u1d
     !real(rp), allocatable, dimension(:,:) :: u2d
     integer :: i,j,k
     logical :: is_noise,is_mean,is_pair
-    real(rp) :: xc,yc,zc,xf,yf,zf
-    real(rp) :: reb,retau
-    real(rp) :: ubulk
+    real(rp) :: xc,yc,zcc,xf,yf,zff
+    real(rp), allocatable, dimension(:) :: zc2
+    real(rp) :: uref
+    real(rp) :: ubulk,reb,retau
     integer, dimension(3) :: n
     !
     n(:) = shape(p) - 2*1
@@ -37,56 +38,76 @@ module mod_initflow
     is_noise = .false.
     is_mean  = .false.
     is_pair  = .false.
+    uref  = 1.
     ubulk = uref
+    if(is_forced(1)) ubulk = velf(1)
     select case(trim(inivel))
     case('cou')
-      call couette(   n(3),zclzi,ubulk,u1d)
+      uref = (bcvel(0,3,1)-bcvel(1,3,1)) ! uref = (ubot - utop)
+      call couette(   n(3),zc/lz,uref ,u1d)
+      uref = abs(uref)
     case('poi')
-      call poiseuille(n(3),zclzi,ubulk,u1d)
-      is_mean=.true.
+      call poiseuille(n(3),zc/lz,ubulk,u1d)
+      is_mean = .true.
     case('tbl')
-      call temporal_bl(n(3),zclzi*lz,1._rp,visc,uref,u1d)
+      call temporal_bl(n(3),zc,1._rp,visc,uref,u1d)
     case('iop') ! reversed 'poi'
-      call poiseuille(n(3),zclzi,ubulk,u1d)
+      !
+      ! convective reference frame moving with velocit `ubulk`;
+      ! walls have negative velocity equal to `ubulk` in the laboratory frame
+      !
+      ubulk = 0.5*abs(bcvel(0,3,1)+bcvel(1,3,1))
+      call poiseuille(n(3),zc/lz,ubulk,u1d)
       u1d(:) = u1d(:) - ubulk
     case('zer')
       u1d(:) = 0.
     case('uni')
       u1d(:) = uref
     case('log')
-      call log_profile(n(3),zclzi,ubulk*lref/visc,u1d)
+      reb = ubulk*lz/visc
+      call log_profile(n(3),zc/lz,reb,u1d)
       is_noise = .true.
       is_mean = .true.
     case('hcl')
       deallocate(u1d)
       allocate(u1d(2*n(3)))
-      call log_profile(2*n(3),zclzi,ubulk*lref/visc,u1d)
+      allocate(zc2(0:2*n(3)+1))
+      zc2(1     :  n(3)) =        zc(1   :n(3): 1)
+      zc2(n(3)+1:2*n(3)) = 2*lz - zc(n(3):1   :-1)
+      zc2(0)        = -zc(0)
+      zc2(2*n(3)+1) = 2*lz + zc(0)
+      reb = ubulk*(2*lz)/visc
+      call log_profile(2*n(3),zc2/(2*lz),reb,u1d)
       is_noise = .true.
       is_mean=.true.
     case('hcp')
       deallocate(u1d)
       allocate(u1d(2*n(3)))
-      call poiseuille(2*n(3),zclzi,ubulk,u1d)
+      allocate(zc2(0:2*n(3)+1))
+      zc2(1     :  n(3)) =        zc(1   :n(3): 1)
+      zc2(n(3)+1:2*n(3)) = 2*lz - zc(n(3):1   :-1)
+      zc2(0)        = -zc(0)
+      zc2(2*n(3)+1) = 2*lz + zc(0)
+      call poiseuille(2*n(3),zc2/(2*lz),ubulk,u1d)
       is_mean = .true.
     case('tgv')
       do k=1,n(3)
-        zc = zclzi(k)*2.*pi
+        zcc = zc(k)/lz*2.*pi
         do j=1,n(2)
           yc = (j+lo(2)-1-.5)*dy/ly*2.*pi
           yf = (j+lo(2)-1-.0)*dy/ly*2.*pi
           do i=1,n(1)
             xc = (i+lo(1)-1-.5)*dx/lx*2.*pi
             xf = (i+lo(1)-1-.0)*dx/lx*2.*pi
-            u(i,j,k) =  sin(xf)*cos(yc)*cos(zc)*uref
-            v(i,j,k) = -cos(xc)*sin(yf)*cos(zc)*uref
+            u(i,j,k) =  sin(xf)*cos(yc)*cos(zcc)*uref
+            v(i,j,k) = -cos(xc)*sin(yf)*cos(zcc)*uref
             w(i,j,k) = 0.
-            p(i,j,k) = 0.!(cos(2.*xc)+cos(2.*yc))*(cos(2.*zc)+2.)/16.*uref**2
+            p(i,j,k) = 0.!(cos(2.*xc)+cos(2.*yc))*(cos(2.*zcc)+2.)/16.*uref**2
           end do
         end do
       end do
     case('tgw')
       do k=1,n(3)
-        zc = zclzi(k)
         do j=1,n(2)
           yc = (j+lo(2)-1-.5)*dy
           yf = (j+lo(2)-1-.0)*dy
@@ -102,13 +123,14 @@ module mod_initflow
       end do
     case('pdc')
       if(is_wallturb) then ! turbulent flow
-        retau = uref*lref/visc
+        uref  = (bforce(1)/(lz/2.))**(0.5)
+        retau = uref*(lz/2.)/visc
         reb   = (retau/.09)**(1./.88)
         ubulk = (reb/2.)/retau*uref
       else                 ! laminar flow
-        ubulk = (bforce(1)*lref**2/(3.*visc))
+        ubulk = (bforce(1)*(lz/2.)**2/(3.*visc))
       end if
-      call poiseuille(n(3),zclzi,ubulk,u1d)
+      call poiseuille(n(3),zc/lz,ubulk,u1d)
       is_mean=.true.
     case default
       if(myid == 0) print*, 'ERROR: invalid name for initial velocity field'
@@ -136,7 +158,7 @@ module mod_initflow
       call add_noise(ng,lo,789,.05_rp,w(1:n(1),1:n(2),1:n(3)))
     end if
     if(is_mean) then
-      call set_mean(n,ubulk,dzflzi*(dx/lx)*(dy/ly),u(1:n(1),1:n(2),1:n(3)))
+      call set_mean(n,ubulk,dzf/lz*(dx/lx)*(dy/ly),u(1:n(1),1:n(2),1:n(3)))
     end if
     if(is_wallturb) is_pair = .true.
     if(is_pair) then
@@ -151,8 +173,8 @@ module mod_initflow
       ! see Henningson and Kim, JFM 1991
       !
       do k=1,n(3)
-        zc = 2.*zclzi(k) - 1. ! z rescaled to be between -1 and +1
-        zf = 2.*(zclzi(k) + .5*dzflzi(k)) - 1.
+        zcc = 2.*zc(k)/lz - 1. ! z rescaled to be between -1 and +1
+        zff = 2.*(zc(k)/lz + .5*dzf(k)/lz) - 1.
         do j=1,n(2)
           yc = ((lo(2)-1+j-0.5)*dy-.5*ly)*2./lz
           yf = ((lo(2)-1+j-0.0)*dy-.5*ly)*2./lz
@@ -160,8 +182,8 @@ module mod_initflow
             xc = ((lo(1)-1+i-0.5)*dx-.5*lx)*2./lz
             xf = ((lo(1)-1+i-0.0)*dx-.5*lx)*2./lz
             !u(i,j,k) = u1d(k)
-            v(i,j,k) = -1. * gxy(yf,xc)*dfz(zc) * ubulk * 1.5
-            w(i,j,k) =  1. * fz(zf)*dgxy(yc,xc) * ubulk * 1.5
+            v(i,j,k) = -1.*gxy(yf,xc)*dfz(zcc)*ubulk*1.5
+            w(i,j,k) =  1.*fz(zff)*dgxy(yc,xc)*ubulk*1.5
             p(i,j,k) = 0.
           end do
         end do
@@ -172,8 +194,8 @@ module mod_initflow
       ! (commented below)
       !
       !do k=1,n(3)
-      !  zc = (zclzi(k)              )*2.*pi
-      !  zf = (zclzi(k)+0.5*dzclzi(k))*2.*pi
+      !  zcc = (zc(k)/lz              )*2.*pi
+      !  zff = (zc(k)/lz+0.5*dzc(k)/lz)*2.*pi
       !  do j=1,n(2)
       !    yc = (j+lo(2)-1-.5)*dy/ly*2.*pi
       !    yf = (j+lo(2)-1-.0)*dy/ly*2.*pi
@@ -181,14 +203,13 @@ module mod_initflow
       !      xc = (i+lo(1)-1-.5)*dx/lx*2.*pi
       !      xf = (i+lo(1)-1-.0)*dx/lx*2.*pi
       !      !u(i,j,k) = u1d(k)
-      !      v(i,j,k) =  sin(xc)*cos(yf)*cos(zc)*ubulk
-      !      w(i,j,k) = -cos(xc)*sin(yc)*cos(zf)*ubulk
-      !      p(i,j,k) = 0.!(cos(2.*xc)+cos(2.*yc))*(cos(2.*zc)+2.)/16.
+      !      v(i,j,k) =  sin(xc)*cos(yf)*cos(zcc)*ubulk
+      !      w(i,j,k) = -cos(xc)*sin(yc)*cos(zff)*ubulk
+      !      p(i,j,k) = 0.!(cos(2.*xc)+cos(2.*yc))*(cos(2.*zcc)+2.)/16.
       !    end do
       !  end do
       !end do
     end if
-    deallocate(u1d)
   end subroutine initflow
   !
   subroutine add_noise(ng,lo,iseed,norm,p)
@@ -313,7 +334,7 @@ module mod_initflow
     real(rp) :: z,retau ! z/lz and bulk Reynolds number
     retau = 0.09*reb**(0.88) ! from Pope's book
     do k=1,n
-      z    = zc(k)*2.*retau
+      z = zc(k)*2.*retau
       if(z >= retau) z = 2.*retau-z
       p(k) = 2.5*log(z) + 5.5
       if (z <= 11.6) p(k)=z

--- a/src/main.f90
+++ b/src/main.f90
@@ -46,7 +46,7 @@ program cans
   use mod_load           , only: load
   use mod_rk             , only: rk
   use mod_output         , only: out0d,gen_alias,out1d,out1d_chan,out2d,out3d,write_log_output,write_visu_2d,write_visu_3d
-  use mod_param          , only: lz,uref,lref,rey,visc,small, &
+  use mod_param          , only: lz,visc,small, &
                                  nb,is_bound,cbcvel,bcvel,cbcpre,bcpre, &
                                  icheck,iout0d,iout1d,iout2d,iout3d,isave, &
                                  nstep,time_max,tw_max,stop_type,restart,is_overwrite_save,nsaves_max, &
@@ -309,7 +309,7 @@ program cans
     istep = 0
     time = 0.
     !$acc update self(zc,dzc,dzf)
-    call initflow(inivel,ng,lo,zc/lz,dzc/lz,dzf/lz,visc,u,v,w,p)
+    call initflow(inivel,ng,lo,zc,dzc,dzf,visc,u,v,w,p)
     if(myid == 0) print*, '*** Initial condition succesfully set ***'
   else
     call load('r',trim(datadir)//'fld.bin',MPI_COMM_WORLD,ng,[1,1,1],lo,hi,u,v,w,p,time,istep)

--- a/src/param.f90
+++ b/src/param.f90
@@ -30,7 +30,7 @@ real(rp), parameter, dimension(3)   :: rkcoeff12 = rkcoeff(1,:)+rkcoeff(2,:)
 integer , protected :: itot,jtot,ktot
 real(rp), protected :: lx,ly,lz,dx,dy,dz,dxi,dyi,dzi,gr
 real(rp), protected :: cfl,dtmin
-real(rp), protected :: uref,lref,rey,visc
+real(rp), protected :: visci
 !
 character(len=100), protected :: inivel
 logical, protected :: is_wallturb
@@ -59,6 +59,7 @@ integer , protected, dimension(3) :: ng
 real(rp), protected, dimension(3) :: l
 real(rp), protected, dimension(3) :: dl
 real(rp), protected, dimension(3) :: dli
+real(rp), protected :: visc
 #if defined(_OPENACC)
 !
 ! cuDecomp input parameters
@@ -82,7 +83,7 @@ contains
         read(iunit,*,iostat=ierr) lx,ly,lz
         read(iunit,*,iostat=ierr) gr
         read(iunit,*,iostat=ierr) cfl,dtmin
-        read(iunit,*,iostat=ierr) uref,lref,rey
+        read(iunit,*,iostat=ierr) visci
         read(iunit,*,iostat=ierr) inivel
         read(iunit,*,iostat=ierr) is_wallturb
         read(iunit,*,iostat=ierr) nstep, time_max,tw_max
@@ -115,7 +116,7 @@ contains
     dyi = dy**(-1)
     dzi = dz**(-1)
     !
-    visc = uref*lref/rey
+    visc = visci**(-1)
     ng  = [itot,jtot,ktot]
     l   = [lx,ly,lz]
     dl  = [dx,dy,dz]

--- a/tests/lid_driven_cavity/dns.in
+++ b/tests/lid_driven_cavity/dns.in
@@ -2,7 +2,7 @@
 0.03125 1. 1.          ! lx, ly, lz
 0.                     ! gr
 .95 1.e5               ! cfl
-1. 1. 1000.            ! uref, lref, rey
+1000.                  ! visci
 zer                    ! inivel
 F                      ! is_wallturb
 1500 100. 0.1          ! nstep,time_max,tw_max


### PR DESCRIPTION
Replaces input parameters `uref`, `lref`, and `rey`, with the inverse of the fluid viscosity, `visci`.

This is a backwards-incompatible change and the input files should be updated when using newer versions.

Closes #52.