### PR TITLE
NVHPC/cuDecomp build (Snellius specific)

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -1,7 +1,7 @@
 #
 # compiler and compiling profile
 #
-FCOMP=GNU           # options: GNU, NVIDIA, INTEL
+FCOMP=NVIDIA        # other options: GNU, NVIDIA, INTEL
 FFLAGS_OPT=1        # for production runs
 FFLAGS_OPT_MAX=0    # for production runs (more aggressive optimization)
 FFLAGS_DEBUG=0      # for debugging
@@ -12,11 +12,16 @@ FFLAGS_DEBUG_MAX=0  # for thorough debugging
 DEBUG=1                    # best = 1 (no significant performance penalty)
 TIMING=1                   # best = 1
 IMPDIFF=0                  #
-IMPDIFF_1D=0               #
-PENCIL_AXIS=1              # = 1/2/3 for X/Y/Z-aligned pencils
+IMPDIFF_1D=1               #
+PENCIL_AXIS=3              # = 1/2/3 for X/Y/Z-aligned pencils
 SINGLE_PRECISION=0         # perform the whole calculation in single precision
+SCALAR=1                   # turn on scalar transport 
+BOUSSINESQ_BUOYANCY=1      # turn on boussinesq
 #
 # GPU-related
 #
-GPU=0
+GPU=1
 USE_NVTX=0                 # use the NVTX-enabled Git branch 'with-nvtx' to see the markers
+
+#Need to point to the NVHPC libraries
+NVHPC_HOME=$(NVHPC)/Linux_x86_64/2024

--- a/configs/libs.mk
+++ b/configs/libs.mk
@@ -2,8 +2,8 @@ override LIBS += -L$(LIBS_DIR)/2decomp-fft -ldecomp2d
 override INCS += -I$(LIBS_DIR)/2decomp-fft/mod
 
 ifeq ($(strip $(GPU)),1)
-override LIBS += -L$(LIBS_DIR)/cuDecomp/build/lib -lcudecomp -lcudecomp_fort -cudalib=cufft
-override INCS += -I$(LIBS_DIR)/cuDecomp/build/include
+override LIBS += -L$(LIBS_DIR)/cuDecomp/build/lib -L$(NVHPC_HOME)/cuda/lib64 -L$(NVHPC_HOME)/math_libs/12.4/lib64 -lcudecomp -lcudecomp_fort -cudalib=cufft,cutensor 
+override INCS += -I$(LIBS_DIR)/cuDecomp/build/include -I$(NVHPC_HOME)/math_libs/12.4/include
 endif
 
 ifeq ($(strip $(USE_NVTX)),1)

--- a/dependencies/cuDecomp_Makefile
+++ b/dependencies/cuDecomp_Makefile
@@ -1,0 +1,122 @@
+# Update this CONFIGFILE for your system or use command 'make CONFIGFILE=<path to your config file>'
+PWD=$(shell pwd)
+CONFIGFILE=${PWD}/configs/nvhpcsdk.conf
+include ${CONFIGFILE}
+
+MPICXX ?= ${MPI_HOME}/bin/mpicxx
+MPIF90 ?= ${MPI_HOME}/bin/mpif90
+NVCC ?= ${CUDA_HOME}/bin/nvcc
+
+CXXFLAGS=-O3 -std=c++14
+# Note: compiling autotune.cc with -O1 due to double free issues otherwise
+CXXFLAGS_O1=-O1 -std=c++14
+NVFLAGS=-O3 -std=c++14 --ptxas-options=-v -cudart shared
+
+CUDA_CC_LIST ?= 60 70 80
+CUDA_CC_LAST := $(lastword $(sort ${CUDA_CC_LIST}))
+NVFLAGS += $(foreach CC,${CUDA_CC_LIST},-gencode=arch=compute_${CC},code=sm_${CC})
+NVFLAGS += -gencode=arch=compute_${CUDA_CC_LAST},code=compute_${CUDA_CC_LAST}
+
+BUILDDIR=${PWD}/build
+TESTDIR=${PWD}/tests
+EXAMPLEDIR=${PWD}/examples
+BENCHMARKDIR=${PWD}/benchmark
+
+OBJ=${BUILDDIR}/cudecomp.o ${BUILDDIR}/cudecomp_kernels.o ${BUILDDIR}/cudecomp_kernels_rdc.o ${BUILDDIR}/autotune.o
+TESTS_CC=${TESTDIR}/cc/test ${TESTDIR}/cc/fft_test
+TESTS_F90=${TESTDIR}/fortran/test ${TESTDIR}/fortran/fft_test
+
+CUDECOMPLIB=${BUILDDIR}/lib/libcudecomp.so
+CUDECOMPFLIB=${BUILDDIR}/lib/libcudecomp_fort.so
+CUDECOMPMOD=${BUILDDIR}/cudecomp_m.o
+
+INCLUDES = -I${PWD}/include -I${MPI_HOME}/include -I${CUDA_HOME}/include -I${NCCL_HOME}/include  -I${CUTENSOR_HOME}/include -I${CUDACXX_HOME}/include
+LIBS = -L${CUDA_HOME}/lib64 -L${CUTENSOR_HOME}/lib64 -L${NCCL_HOME}/lib -lnccl -lcutensor -lcudart
+FLIBS = -cudalib=nccl,cutensor -lstdc++ -L${CUDA_HOME}/lib64
+BUILD_LIBS = -L${BUILDDIR}/lib -lcudecomp -L${CUDA_HOME}/lib64 -L${CUFFT_HOME}/lib64 -lcudart -lcufft
+BUILD_FLIBS = -L${BUILDDIR}/lib -lcudecomp -lcudecomp_fort -cudalib=cufft
+BUILD_INCLUDES = -I${BUILDDIR}/include -I${CUDA_HOME}/include -I${CUFFT_HOME}/include -I${PWD}/include -I${NCCL_HOME}/include
+
+ifeq ($(strip $(ENABLE_NVSHMEM)),1)
+DEFINES += -DENABLE_NVSHMEM -DNVSHMEM_USE_NCCL
+INCLUDES += -I${NVSHMEM_HOME}/include
+LIBS += -L${CUDA_HOME}/lib64/stubs -lcuda -lnvidia-ml
+FLIBS += -L${CUDA_HOME}/lib64/stubs -lcuda -lnvidia-ml
+BUILD_LIBS += -L${CUDA_HOME}/lib64/stubs -lcuda -lnvidia-ml
+BUILD_FLIBS += -L${CUDA_HOME}/lib64/stubs -lcuda -lnvidia-ml
+ifneq ("$(wildcard ${NVSHMEM_HOME}/lib/libnvshmem_host.so)","")
+LIBS += -L${NVSHMEM_HOME}/lib -lnvshmem_host
+STATIC_LIBS += ${NVSHMEM_HOME}/lib/libnvshmem_device.a
+else
+STATIC_LIBS += ${NVSHMEM_HOME}/lib/libnvshmem.a
+endif
+endif
+ifeq ($(strip $(ENABLE_NVTX)),1)
+DEFINES += -DENABLE_NVTX
+endif
+
+ifeq ($(strip $(MPIF90)),ftn)
+DEFINES += -DMPICH
+endif
+
+LIBS += ${EXTRA_LIBS}
+FLIBS += ${EXTRA_LIBS}
+DEFINES += ${EXTRA_DEFINES}
+
+LIBTARGETS = ${CUDECOMPLIB}
+ifeq ($(strip $(BUILD_FORTRAN)),1)
+LIBTARGETS += ${CUDECOMPFLIB}
+endif
+
+export LIBS FLIBS BUILD_LIBS BUILD_FLIBS INCLUDES BUILD_INCLUDES DEFINES MPICXX MPIF90 NVCC CXXFLAGS NVFLAGS BUILD_FORTRAN
+
+.PHONY: all lib tests benchmark examples
+
+all: lib tests benchmark examples
+
+lib: ${LIBTARGETS}
+	@mkdir -p ${BUILDDIR}/include
+	cp ./include/cudecomp.h ${BUILDDIR}/include
+
+tests: lib
+	cd ${TESTDIR}; make CONFIGFILE=${CONFIGFILE}
+
+benchmark: lib
+	cd ${BENCHMARKDIR}; make CONFIGFILE=${CONFIGFILE}
+
+examples: lib
+	cd ${EXAMPLEDIR}; make CONFIGFILE=${CONFIGFILE}
+
+${BUILDDIR}/autotune.o: src/autotune.cc  include/*.h include/internal/*.h
+	@mkdir -p ${BUILDDIR}
+	${MPICXX} -fPIC ${DEFINES} ${CXXFLAGS_O1} ${INCLUDES} -c -o $@ $<
+
+${BUILDDIR}/%.o: src/%.cc  include/*.h include/internal/*.h
+	@mkdir -p ${BUILDDIR}
+	${MPICXX} -fPIC ${DEFINES} ${CXXFLAGS} ${INCLUDES} -c -o $@ $<
+
+${BUILDDIR}/cudecomp_kernels_rdc.o: src/cudecomp_kernels_rdc.cu  include/internal/*.cuh
+	@mkdir -p ${BUILDDIR}
+	${NVCC} -rdc=true -Xcompiler -fPIC ${DEFINES} ${NVFLAGS} ${INCLUDES} -c -o $@ $<
+
+${BUILDDIR}/%.o: src/%.cu  include/internal/*.cuh
+	@mkdir -p ${BUILDDIR}
+	${NVCC} -Xcompiler -fPIC ${DEFINES} ${NVFLAGS} ${INCLUDES} -c -o $@ $<
+
+${CUDECOMPMOD}: src/cudecomp_m.cuf 
+	@mkdir -p ${BUILDDIR}/include
+	${MPIF90} -Mpreprocess -fPIC -module ${BUILDDIR}/include ${DEFINES} ${INCLUDES} -c -o $@ $<
+
+${CUDECOMPLIB}: ${OBJ}
+	@mkdir -p ${BUILDDIR}/lib
+	${NVCC} -shared ${NVFLAGS} ${INCLUDES} ${LIBS} -o $@ $^ ${STATIC_LIBS}
+
+${CUDECOMPFLIB}: ${CUDECOMPMOD}
+	@mkdir -p ${BUILDDIR}/lib
+	${MPIF90} -shared ${INCLUDES} -o $@ $^
+
+clean:
+	rm -f ${CUDECOMPLIB} ${CUDECOMPFLIB} ${BUILDDIR}/*.o ${BUILDDIR}/include/*.mod ${BUILDDIR}/include/*.h
+	cd ${TESTDIR}; make clean
+	cd ${BENCHMARKDIR}; make clean
+	cd ${EXAMPLEDIR}; make clean

--- a/dependencies/external.mk
+++ b/dependencies/external.mk
@@ -4,6 +4,8 @@
 ifeq ($(strip $(GPU)),1)
 libs: $(wildcard $(LIBS_DIR)/2decomp-fft/src/*.f90)
 	cd $(LIBS_DIR)/2decomp-fft && make
+	cp $(LIBS_DIR)/cuDecomp_Makefile $(LIBS_DIR)/cuDecomp/Makefile
+	cp $(LIBS_DIR)/nvhpcsdk.conf $(LIBS_DIR)/cuDecomp/configs/
 	cd $(LIBS_DIR)/cuDecomp && make lib -j
 libsclean: $(wildcard $(LIBS_DIR)/2decomp-fft/src/*.f90)
 	cd $(LIBS_DIR)/2decomp-fft && make clean

--- a/dependencies/nvhpcsdk.conf
+++ b/dependencies/nvhpcsdk.conf
@@ -1,0 +1,18 @@
+NVHPC_HOME=/opt/nvidia/hpc_sdk/Linux_x86_64/2022
+
+# Required variables to define
+MPICXX=mpicxx
+MPIF90=mpifort
+CUDA_HOME=${NVHPC_HOME}/cuda
+MPI_HOME=${NVHPC_HOME}/comm_libs/hpcx/latest/ompi
+NCCL_HOME=${NVHPC_HOME}/comm_libs/nccl
+CUFFT_HOME=${NVHPC_HOME}/math_libs
+CUTENSOR_HOME=${NVHPC_HOME}/math_libs
+CUDACXX_HOME=${CUDA_HOME}
+
+# Optional variables
+CUDA_CC_LIST=60 70 80
+BUILD_FORTRAN=1
+ENABLE_NVTX=1
+ENABLE_NVSHMEM=1
+NVSHMEM_HOME=${NVHPC_HOME}/comm_libs/nvshmem

--- a/dependencies/nvhpcsdk.conf
+++ b/dependencies/nvhpcsdk.conf
@@ -1,18 +1,20 @@
-NVHPC_HOME=/opt/nvidia/hpc_sdk/Linux_x86_64/2022
-
+NVHPC_HOME=/sw/arch/RHEL8/EB_production/2023/software/NVHPC/24.5-CUDA-12.1.1/Linux_x86_64/24.5
 # Required variables to define
 MPICXX=mpicxx
 MPIF90=mpifort
-CUDA_HOME=${NVHPC_HOME}/cuda
-MPI_HOME=${NVHPC_HOME}/comm_libs/hpcx/latest/ompi
-NCCL_HOME=${NVHPC_HOME}/comm_libs/nccl
-CUFFT_HOME=${NVHPC_HOME}/math_libs
-CUTENSOR_HOME=${NVHPC_HOME}/math_libs
+CUDA_HOME=/sw/arch/RHEL8/EB_production/2023/software/CUDA/12.1.1
+#CUDA_HOME=${NVHPC_HOME}/cuda/12.4
+MPI_HOME=/sw/arch/RHEL8/EB_production/2023/software/OpenMPI/4.1.5-NVHPC-24.5-CUDA-12.1.1
+#${NVHPC_HOME}/comm_libs/12.4/hpcx/latest/ompi
+NCCL_HOME=/sw/arch/RHEL8/EB_production/2023/software/NCCL/2.18.3-GCCcore-12.3.0-CUDA-12.1.1
+#${NVHPC_HOME}/comm_libs/12.4/nccl
+CUFFT_HOME=${NVHPC_HOME}/math_libs/12.4
+CUTENSOR_HOME=${NVHPC_HOME}/math_libs/12.4
 CUDACXX_HOME=${CUDA_HOME}
 
 # Optional variables
-CUDA_CC_LIST=60 70 80
+CUDA_CC_LIST=70 80 90
 BUILD_FORTRAN=1
-ENABLE_NVTX=1
-ENABLE_NVSHMEM=1
-NVSHMEM_HOME=${NVHPC_HOME}/comm_libs/nvshmem
+ENABLE_NVTX=0
+ENABLE_NVSHMEM=0
+NVSHMEM_HOME=${NVHPC_HOME}/comm_libs/12.4/nvshmem


### PR DESCRIPTION
This should fix the H100 build problems with Snellius. There are too many hard coded paths in my opinion. So the build scripts/config files could absolutely be cleaned up, and made generic. And there are some specific cuDecomp Makefile additions.
I will leave it to you guys to decide how to incorporate it into CaNs.
I would suggest making a `build.snellius.conf` and `dependencies/cuDecomp/configs/nvhpcsdk.snellius.conf` to be snellius specific

I suggest that we use the PR to "polish up" the changes