### PR TITLE
`*clean` targets do not need dependencies file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,10 @@ $(DEPS):
 	@$(foreach file, $(SRCS), $(GD) $(file) >> $(DEPS))
 
 # Define all module interdependencies
+ifneq ($(filter clean libsclean allclean,$(MAKECMDGOALS)),)
+else
 -include $(DEPS)
+endif
 $(foreach dep, $(OBJS), $(eval $(dep): $($(dep))))
 
 # Cleanup, filter to avoid removing source code by accident


### PR DESCRIPTION
This avoids errors like:

```shell
build/.depend.mk:161: *** empty variable name.  Stop.
```

When doing `make clean` and the target compiler has changed.