### PR TITLE
Enable error reporting for errors in namelists.

### DIFF
--- a/examples/_manuscript_lid_driven_cavity/input.nml
+++ b/examples/_manuscript_lid_driven_cavity/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/_manuscript_taylor_green_vortex/input.nml
+++ b/examples/_manuscript_taylor_green_vortex/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/_manuscript_turbulent_channel/input.nml
+++ b/examples/_manuscript_turbulent_channel/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = T, F, F
 velf(1:3) = 1., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/_manuscript_turbulent_duct/input.nml
+++ b/examples/_manuscript_turbulent_duct/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = T, F, F
 velf(1:3) = 1., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/closed_box/input.nml
+++ b/examples/closed_box/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/couette/input.nml
+++ b/examples/couette/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/developing_channel/input.nml
+++ b/examples/developing_channel/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/developing_duct/input.nml
+++ b/examples/developing_duct/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/half_channel/input.nml
+++ b/examples/half_channel/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = T, F, F
 velf(1:3) = 1., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/lid_driven_cavity/input.nml
+++ b/examples/lid_driven_cavity/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/periodic_channel/input.nml
+++ b/examples/periodic_channel/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = T, F, F
 velf(1:3) = 1., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/periodic_duct/input.nml
+++ b/examples/periodic_duct/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = T, F, F
 velf(1:3) = 1., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/taylor_green_vortex_2d/input.nml
+++ b/examples/taylor_green_vortex_2d/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 1, 1
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/temporal_boundary_layer/input.nml
+++ b/examples/temporal_boundary_layer/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/triperiodic/input.nml
+++ b/examples/triperiodic/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/turbulent_channel_constant_pressure_gradient/input.nml
+++ b/examples/turbulent_channel_constant_pressure_gradient/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 1., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/turbulent_channel_convective_reference_frame/input.nml
+++ b/examples/turbulent_channel_convective_reference_frame/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = T, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/examples/turbulent_half_channel_constant_pressure_gradient/input.nml
+++ b/examples/turbulent_half_channel_constant_pressure_gradient/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 1., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/src/input.nml
+++ b/src/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = T, F, F
 velf(1:3) = 1., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/

--- a/src/param.f90
+++ b/src/param.f90
@@ -61,6 +61,7 @@ real(rp), protected, dimension(3) :: velf
 !
 real(rp), protected, dimension(3) :: dl,dli
 real(rp), protected :: visc
+!
 #if defined(_OPENACC)
 !
 ! cuDecomp input parameters
@@ -70,14 +71,15 @@ logical, protected :: cudecomp_is_t_comm_autotune ,cudecomp_is_h_comm_autotune ,
                       cudecomp_is_t_enable_nccl   ,cudecomp_is_h_enable_nccl   , &
                       cudecomp_is_t_enable_nvshmem,cudecomp_is_h_enable_nvshmem, &
                       cudecomp_is_t_in_place
-logical :: exists
 #endif
 contains
   subroutine read_input(myid)
     use mpi
     implicit none
+    character(len=*), parameter :: input_file = 'input.nml'
     integer, intent(in) :: myid
     integer :: iunit,ierr
+    character(len=1024) :: c_iomsg
     namelist /dns/ &
                   ng, &
                   l, &
@@ -104,84 +106,91 @@ contains
     ! defaults
     !
     dt_f = -1.
-    open(newunit=iunit,file='input.nml',status='old',action='read',iostat=ierr)
-      if(ierr == 0) then
-        read(iunit,nml=dns,iostat=ierr)
-      else
-        if(myid == 0) print*, 'Error reading the input file'
+    open(newunit=iunit,file=input_file,status='old',action='read',iostat=ierr,iomsg=c_iomsg)
+      if(ierr /= 0) then
+        if(myid == 0) print*, 'Error reading the input file: ', trim(c_iomsg)
         if(myid == 0) print*, 'Aborting...'
         call MPI_FINALIZE(ierr)
+        close(iunit)
         error stop
       end if
-    close(iunit)
-    !
-    dl(:) = l(:)/(1.*ng(:))
-    dli(:) = dl(:)**(-1)
-    visc = visci**(-1)
+      read(iunit,nml=dns,iostat=ierr,iomsg=c_iomsg)
+      if(ierr /= 0) then
+        if(myid == 0) print*, 'Error reading dns namelist: ', trim(c_iomsg)
+        if(myid == 0) print*, 'Aborting...'
+        call MPI_FINALIZE(ierr)
+        close(iunit)
+        error stop
+      end if
+      !
+      dl(:) = l(:)/(1.*ng(:))
+      dli(:) = dl(:)**(-1)
+      visc = visci**(-1)
 #if defined(_OPENACC)
-    !
-    ! reading cuDecomp parameters, if these are set
-    !
-    ! defaults
-    !
-    cudecomp_is_t_comm_autotune  = .true.
-    cudecomp_is_h_comm_autotune  = .true.
-    cudecomp_is_t_enable_nccl    = .true.
-    cudecomp_is_h_enable_nccl    = .true.
-    cudecomp_is_t_enable_nvshmem = .true.
-    cudecomp_is_h_enable_nvshmem = .true.
-    open(newunit=iunit,file='input.nml',status='old',action='read',iostat=ierr)
-      if(ierr == 0) then
-        read(iunit,nml=cudecomp,iostat=ierr)
-      else
-        if(myid == 0) print*, 'Error reading the input file'
+      !
+      ! reading cuDecomp parameters, if these are set
+      !
+      ! defaults
+      !
+      cudecomp_is_t_comm_autotune  = .true.
+      cudecomp_is_h_comm_autotune  = .true.
+      cudecomp_is_t_enable_nccl    = .true.
+      cudecomp_is_h_enable_nccl    = .true.
+      cudecomp_is_t_enable_nvshmem = .true.
+      cudecomp_is_h_enable_nvshmem = .true.
+      rewind(iunit)
+      read(iunit,nml=cudecomp,iostat=ierr,iomsg=c_iomsg)
+      if(ierr /= 0) then
+        if(myid == 0) print*, 'Error reading cudecomp namelist: ', trim(c_iomsg)
         if(myid == 0) print*, 'Aborting...'
         call MPI_FINALIZE(ierr)
+        close(iunit)
         error stop
       end if
-    close(iunit)
-    if(cudecomp_t_comm_backend >= 1 .and. cudecomp_t_comm_backend <= 7) then
-      cudecomp_is_t_comm_autotune = .false. ! do not autotune if backend is prescribed
-      select case(cudecomp_t_comm_backend)
-      case(1)
-        cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_MPI_P2P
-      case(2)
-        cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_MPI_P2P_PL
-      case(3)
-        cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_MPI_A2A
-      case(4)
-        cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_NCCL
-      case(5)
-        cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_NCCL_PL
-      case(6)
-        cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_NVSHMEM
-      case(7)
-        cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL
-      case default
-        cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_MPI_P2P
-      end select
-    end if
-    if(cudecomp_h_comm_backend >= 1 .and. cudecomp_h_comm_backend <= 4) then
-      cudecomp_is_h_comm_autotune = .false. ! do not autotune if backend is prescribed
-      select case(cudecomp_h_comm_backend)
-      case(1)
-        cudecomp_h_comm_backend = CUDECOMP_HALO_COMM_MPI
-      case(2)
-        cudecomp_h_comm_backend = CUDECOMP_HALO_COMM_MPI_BLOCKING
-      case(3)
-        cudecomp_h_comm_backend = CUDECOMP_HALO_COMM_NCCL
-      case(4)
-        cudecomp_h_comm_backend = CUDECOMP_HALO_COMM_NVSHMEM
-      case(5)
-        cudecomp_h_comm_backend = CUDECOMP_HALO_COMM_NVSHMEM_BLOCKING
-      case default
-        cudecomp_h_comm_backend = CUDECOMP_HALO_COMM_MPI
-      end select
-    end if
-    !
-    ! manually set cuDecomp out-of-place transposes by default
-    !
-    cudecomp_is_t_in_place = .false.
+      !
+      if(cudecomp_t_comm_backend >= 1 .and. cudecomp_t_comm_backend <= 7) then
+        cudecomp_is_t_comm_autotune = .false. ! do not autotune if backend is prescribed
+        select case(cudecomp_t_comm_backend)
+        case(1)
+          cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_MPI_P2P
+        case(2)
+          cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_MPI_P2P_PL
+        case(3)
+          cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_MPI_A2A
+        case(4)
+          cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_NCCL
+        case(5)
+          cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_NCCL_PL
+        case(6)
+          cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_NVSHMEM
+        case(7)
+          cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL
+        case default
+          cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_MPI_P2P
+        end select
+      end if
+      if(cudecomp_h_comm_backend >= 1 .and. cudecomp_h_comm_backend <= 4) then
+        cudecomp_is_h_comm_autotune = .false. ! do not autotune if backend is prescribed
+        select case(cudecomp_h_comm_backend)
+        case(1)
+          cudecomp_h_comm_backend = CUDECOMP_HALO_COMM_MPI
+        case(2)
+          cudecomp_h_comm_backend = CUDECOMP_HALO_COMM_MPI_BLOCKING
+        case(3)
+          cudecomp_h_comm_backend = CUDECOMP_HALO_COMM_NCCL
+        case(4)
+          cudecomp_h_comm_backend = CUDECOMP_HALO_COMM_NVSHMEM
+        case(5)
+          cudecomp_h_comm_backend = CUDECOMP_HALO_COMM_NVSHMEM_BLOCKING
+        case default
+          cudecomp_h_comm_backend = CUDECOMP_HALO_COMM_MPI
+        end select
+      end if
+      !
+      ! manually set cuDecomp out-of-place transposes by default
+      !
+      cudecomp_is_t_in_place = .false.
 #endif
+    close(iunit)
   end subroutine read_input
 end module mod_param

--- a/tests/lid_driven_cavity/input.nml
+++ b/tests/lid_driven_cavity/input.nml
@@ -22,9 +22,9 @@ bforce(1:3) = 0., 0., 0.
 is_forced(1:3) = F, F, F
 velf(1:3) = 0., 0., 0.
 dims(1:2) = 0, 0
-\
+/
 
 &cudecomp
 cudecomp_t_comm_backend = 0, cudecomp_is_t_enable_nccl = T, cudecomp_is_t_enable_nvshmem = T
 cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable_nvshmem = T
-\
+/


### PR DESCRIPTION
Contribution from @v1kko in the framework of the [ExaFlow](https://research-software-directory.org/projects/exaflow) project:

> An error in a namelist would not fail (or fail silently), but no more!
> This PR enables the printing of the line in which an error in the namelist is encountered, and stops the program if this is the case.
> Also all namelists ended with \ (which is an error, although harmless because all variables have already been read), but they should end with /, this PR also fixes that.

Thanks again!