### PR TITLE
Revert "Remove masking of output of coarsened field. (#130)"

### DIFF
--- a/src/output.f90
+++ b/src/output.f90
@@ -204,7 +204,7 @@ module mod_output
     filesize = 0_MPI_OFFSET_KIND
     call MPI_FILE_SET_SIZE(fh,filesize,ierr)
     disp = 0_MPI_OFFSET_KIND
-#if 1
+#if !defined(_OPENACC)
     call decomp_2d_write_every(ipencil,p,nskip(1),nskip(2),nskip(3),fname,.true.)
 #else
     !


### PR DESCRIPTION
This reverts commit 96355536dfbbf93ecdb371a506111e5ede765c3c.

Unfortunately, there is an issue with the i/o features of `2decomp`, so we should revert to our implementation until this issue is resolved.