### PR TITLE
Avoid unecessary copies in the Poisson solver.

### DIFF
--- a/src/common_cudecomp.f90
+++ b/src/common_cudecomp.f90
@@ -15,7 +15,7 @@ module mod_common_cudecomp
   public
   integer :: cudecomp_real_rp
   type(cudecompHandle)     :: handle
-  type(cudecompGridDesc)   :: gd_halo,gd_poi
+  type(cudecompGridDesc)   :: gd_halo,gd_poi,gd_poi_io
   type(cudecompPencilInfo) :: ap_x,ap_y,ap_z,ap_x_poi,ap_y_poi,ap_z_poi
   type(cudecompGridDesc)   :: gd_ptdma
   type(cudecompPencilInfo) :: ap_y_ptdma,ap_z_ptdma

--- a/src/initflow.f90
+++ b/src/initflow.f90
@@ -209,38 +209,38 @@ module mod_initflow
     end if
     if(is_wallturb) is_pair = .true.
     if(is_pair) then
-      !
-      ! initialize a streamwise vortex pair for a fast transition
-      ! to turbulence in a pressure-driven channel:
-      !        psi(x,y,z)  = f(z)*g(x,y), with
-      !        f(z)        = (1-z**2)**2, and
-      !        g(x,y)      = y*exp[-(16x**2-4y**2)]
-      ! (x,y,z) --> (streamwise, spanwise, wall-normal) directions
-      !
-      ! see Henningson and Kim, JFM 1991
-      !
-      do k=1,n(3)
-        zcc = 2.*zc(k)/l(3) - 1. ! z rescaled to be between -1 and +1
-        zff = 2.*(zc(k)/l(3) + .5*dzf(k)/l(3)) - 1.
-        do j=1,n(2)
-          yc = ((lo(2)-1+j-0.5)*dl(2)-.5*l(2))*2./l(3)
-          yf = ((lo(2)-1+j-0.0)*dl(2)-.5*l(2))*2./l(3)
-          do i=1,n(1)
-            xc = ((lo(1)-1+i-0.5)*dl(1)-.5*l(1))*2./l(3)
-            xf = ((lo(1)-1+i-0.0)*dl(1)-.5*l(1))*2./l(3)
-            !u(i,j,k) = u1d(k)
-            v(i,j,k) = -1.*gxy(yf,xc)*dfz(zcc)*ubulk*1.5
-            w(i,j,k) =  1.*fz(zff)*dgxy(yc,xc)*ubulk*1.5
-            p(i,j,k) = 0.
+      if(.false.) then
+        !
+        ! initialize a streamwise vortex pair for a fast transition
+        ! to turbulence in a pressure-driven channel:
+        !        psi(x,y,z)  = f(z)*g(x,y), with
+        !        f(z)        = (1-z**2)**2, and
+        !        g(x,y)      = y*exp[-(16x**2-4y**2)]
+        ! (x,y,z) --> (streamwise, spanwise, wall-normal) directions
+        !
+        ! see Henningson and Kim, JFM 1991
+        !
+        do k=1,n(3)
+          zcc = 2.*zc(k)/l(3) - 1. ! z rescaled to be between -1 and +1
+          zff = 2.*(zc(k)/l(3) + .5*dzf(k)/l(3)) - 1.
+          do j=1,n(2)
+            yc = ((lo(2)-1+j-0.5)*dl(2)-.5*l(2))*2./l(3)
+            yf = ((lo(2)-1+j-0.0)*dl(2)-.5*l(2))*2./l(3)
+            do i=1,n(1)
+              xc = ((lo(1)-1+i-0.5)*dl(1)-.5*l(1))*2./l(3)
+              xf = ((lo(1)-1+i-0.0)*dl(1)-.5*l(1))*2./l(3)
+              !u(i,j,k) = u1d(k)
+              v(i,j,k) = -1.*gxy(yf,xc)*dfz(zcc)*ubulk*1.5
+              w(i,j,k) =  1.*fz(zff)*dgxy(yc,xc)*ubulk*1.5
+              p(i,j,k) = 0.
+            end do
           end do
         end do
-      end do
-      !
-      ! alternatively, using a Taylor-Green vortex
-      ! for the cross-stream velocity components
-      ! (commented below)
-      !
-      if(.false.) then
+      else
+        !
+        ! alternatively, using a Taylor-Green vortex
+        ! for the cross-stream velocity components
+        !
         do k=1,n(3)
           zcc = (zc(k)/l(3)                )*2.*pi
           zff = (zc(k)/l(3)+0.5*dzc(k)/l(3))*2.*pi

--- a/src/initmpi.f90
+++ b/src/initmpi.f90
@@ -17,7 +17,7 @@ module mod_initmpi
   !@cuf use cudafor, only: cudaGetDeviceCount,cudaSetDevice
 #if defined(_OPENACC)
   use mod_common_cudecomp, only: cudecomp_real_rp, &
-                                 ch => handle,gd => gd_halo,gd_poi, &
+                                 ch => handle,gd => gd_halo,gd_poi,gd_poi_io, &
                                  ap_x,ap_y,ap_z,ap_x_poi,ap_y_poi,ap_z_poi, &
                                  gd_ptdma,ap_y_ptdma,ap_z_ptdma
   use mod_param, only: cudecomp_t_comm_backend     ,cudecomp_h_comm_backend    , &
@@ -46,7 +46,7 @@ module mod_initmpi
     integer(acc_device_kind) ::dev_type
     integer :: local_comm,mydev,ndev
     integer :: istat
-    type(cudecompGridDescConfig)          :: conf,conf_poi
+    type(cudecompGridDescConfig)          :: conf,conf_poi,conf_poi_io
     type(cudecompGridDescAutotuneOptions) :: atune_conf
     type(cudecompGridDescConfig)          :: conf_ptdma
 #else
@@ -120,6 +120,11 @@ module mod_initmpi
     !
     istat = cudecompGridDescCreate(ch,gd_poi,conf,atune_conf)
     conf_poi = conf
+    conf_poi_io = conf
+    conf_poi_io%transpose_axis_contiguous(:) = .true.
+    conf_poi_io%transpose_axis_contiguous(ipencil) = .false.
+    conf_poi_io%gdims(:) = ng(:)
+    istat = cudecompGridDescCreate(ch,gd_poi_io,conf_poi_io)
     dims(:) = conf%pdims(:)
     if(is_poisson_pcr_tdma) then
       istat = cudecompGridDescConfigSetDefaults(conf_ptdma)

--- a/src/main.f90
+++ b/src/main.f90
@@ -73,7 +73,7 @@ program cans
   use mod_solver         , only: solver
 #else
   use mod_solver_gpu     , only: solver => solver_gpu
-  use mod_workspaces     , only: init_wspace_arrays,set_cufft_wspace
+  use mod_workspaces     , only: init_wspace_arrays,set_cufft_wspace,cudecomp_finalize
   use mod_common_cudecomp, only: istream_acc_queue_1,ap_z_ptdma
 #endif
   use mod_timer          , only: timer_tic,timer_toc,timer_print
@@ -630,5 +630,8 @@ program cans
   end if
   if(myid == 0.and.(.not.kill)) print*, '*** Fim ***'
   call decomp_2d_finalize
+#if defined(_OPENACC)
+  call cudecomp_finalize
+#endif
   call MPI_FINALIZE(ierr)
 end program cans

--- a/src/workspaces.f90
+++ b/src/workspaces.f90
@@ -11,7 +11,7 @@ module mod_workspaces
   use mod_utils, only: f_sizeof
   implicit none
   private
-  public init_wspace_arrays,set_cufft_wspace
+  public init_wspace_arrays,set_cufft_wspace,cudecomp_finalize
 contains
   subroutine init_wspace_arrays
     use mod_common_cudecomp, only: handle,gd_halo,gd_poi,gd_ptdma, &
@@ -98,5 +98,18 @@ contains
       end if
     end do
   end subroutine set_cufft_wspace
+  subroutine cudecomp_finalize
+    use cudecomp
+    use mod_common_cudecomp, only: handle,gd_halo,gd_poi,gd_poi_io,gd_ptdma
+    use mod_param          , only: is_poisson_pcr_tdma
+    !
+    implicit none
+    integer :: istat
+    istat = cudecompGridDescDestroy(handle,gd_halo)
+    istat = cudecompGridDescDestroy(handle,gd_poi)
+    istat = cudecompGridDescDestroy(handle,gd_poi_io)
+    if(is_poisson_pcr_tdma) istat = cudecompGridDescDestroy(handle,gd_ptdma)
+    istat = cudecompFinalize(handle)
+  end subroutine cudecomp_finalize
 #endif
 end module mod_workspaces


### PR DESCRIPTION
This PR leverages the capabilities of the cuDecomp API to avoid some unnecessary copies that were required for processing its input/output due to the presence of ghost (halo) cells.

I also took the opportunity to:

- Update the cuDecomp submodule
- Write a `cudeocmp_finalize` subroutine that finalizes the library and allows enabling its run performance reporting capabilities; see https://github.com/NVIDIA/cuDecomp/pull/75
- Add a minor change in the wall-bounded turbulence initial condition

Thanks Josh Romero for the discussion!