### PR TITLE
Ported CaNS to run on LUMI using HIP and diezDecomp.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ run: $(EXE)
 
 # Create object files from Fortran source
 $(OBJS): $(BUILD_DIR)/%.o: $(SRCS_DIR)/%
-	$(FC) $(FFLAGS) $(CPP) $(DEFINES) $(INCS) $(FFLAGS_MOD_DIR) $(BUILD_DIR) -c -o $@ $<
+	$(FC) $(FFLAGS) $(CPP) $(DEFINES) $(INCS) $(FFLAGS_MOD_DIR)$(BUILD_DIR) -c -o $@ $<
 
 # Process the Fortran source for module dependencies
 $(DEPS):

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ P. Costa. *A FFT-based finite-difference solver for massively-parallel direct nu
 ### _Major Update:_ `CaNS 3.0` _is out!_ :tada:
 See the [Release Notes](https://github.com/CaNS-World/CaNS/releases/tag/v3.0.0) for more details.
 
+**[06/08/2025]:** Support for running on AMD-based supercomputers and new GPU communication backend available! CaNS has been ported using to other platforms using HIP and thanks to the recently developed [diezDecomp library](https://github.com/Rafael10Diez/diezDecomp). See the updated `[docs/INFO_COMPILING.md](docs/INFO_COMPILING.md)` for more details.
+
 **[10/04/2025]:** The writing of checkpoint files has changed. To allow for more flexibility, CaNS now writes one file per scalar field, where each velocity component, pressure, and scalar fields is stored in a different checkpoint file.
 
 **[14/02/2025]:** Most pre-processor macros have been turned into runtime arguments, which allow for a much simpler control of the computational setup without re-compiling the source. See the updated [`docs/INFO_INPUT.md`](docs/INFO_INPUT.md) and [`docs/INFO_COMPILING.md`](docs/INFO_COMPILING.md) for more details.
@@ -43,6 +45,7 @@ Some features are:
  * FFTW guru interface / cuFFT used for computing multi-dimensional vectors of 1D transforms
  * The right type of transformation (Fourier, cosine, sine, etc) is automatically determined form the input file
  * [cuDecomp](https://github.com/NVIDIA/cuDecomp) pencil decomposition library for _hardware-adaptive_ distributed memory calculations on _many GPUs_
+ * [diezDecomp](https://github.com/Rafael10Diez/diezDecomp) pencil decomposition library distributed memory calculations on various GPU/CPU hardware platforms
  * [2DECOMP&FFT](https://github.com/xcompact3d/2decomp-fft) library used for performing global data transpositions on CPUs and some of the data I/O
  * GPU acceleration using OpenACC directives
  * A different canonical flow can be simulated just by changing the input files

--- a/configs/defaults/compilers-default.mk
+++ b/configs/defaults/compilers-default.mk
@@ -12,8 +12,15 @@ ifeq ($(strip $(FCOMP)),NVIDIA)
 FC = mpifort
 endif
 ifeq ($(strip $(FCOMP)),CRAY)
+ifneq ($(strip $(GPU)),1)
 FC = ftn
 CPP = -eZ
+else
+FC = hipfc -v
+endif
+endif
+ifeq ($(strip $(FCOMP)),FUJITSU)
+FC = mpifrtpx
 endif
 ifeq ($(strip $(FTN_MPI_WRAPPER)),1)
 FC = ftn

--- a/configs/defaults/flags-default.mk
+++ b/configs/defaults/flags-default.mk
@@ -105,6 +105,7 @@ endif
 CUSTOM_DEFINES =  SINGLE_PRECISION \
 		          LOOP_UNSWITCHING \
 		          DECOMP_X_IO \
+				  USE_DIEZDECOMP \
 		          USE_HIP \
                   USE_NVTX
 

--- a/configs/defaults/libs-default.mk
+++ b/configs/defaults/libs-default.mk
@@ -2,8 +2,13 @@ override LIBS += -L$(LIBS_DIR)/2decomp-fft -ldecomp2d
 override INCS += -I$(LIBS_DIR)/2decomp-fft/mod
 
 ifeq ($(strip $(GPU)),1)
-override LIBS += -L$(LIBS_DIR)/cuDecomp/build/lib -lcudecomp -lcudecomp_fort -cudalib=cufft
+ifneq ($(strip $(USE_DIEZDECOMP)),1)
+override LIBS += -L$(LIBS_DIR)/cuDecomp/build/lib -lcudecomp -lcudecomp_fort
 override INCS += -I$(LIBS_DIR)/cuDecomp/build/include
+else
+override LIBS += -L$(LIBS_DIR)/diezDecomp/build/lib -ldiezdecomp
+override INCS += -I$(LIBS_DIR)/diezDecomp/build/include
+endif
 ifneq ($(strip $(USE_HIP)),1)
 override LIBS += -cudalib=cufft
 else

--- a/configs/defaults/libs-default.mk
+++ b/configs/defaults/libs-default.mk
@@ -4,6 +4,11 @@ override INCS += -I$(LIBS_DIR)/2decomp-fft/mod
 ifeq ($(strip $(GPU)),1)
 override LIBS += -L$(LIBS_DIR)/cuDecomp/build/lib -lcudecomp -lcudecomp_fort -cudalib=cufft
 override INCS += -I$(LIBS_DIR)/cuDecomp/build/include
+ifneq ($(strip $(USE_HIP)),1)
+override LIBS += -cudalib=cufft
+else
+override LIBS += -lhipfft
+endif
 endif
 
 ifeq ($(strip $(USE_NVTX)),1)

--- a/dependencies/diezDecomp/Makefile
+++ b/dependencies/diezDecomp/Makefile
@@ -1,0 +1,62 @@
+.SUFFIXES:
+MAKEFLAGS += --no-builtin-rules --no-builtin-variables
+SHELL=/bin/bash
+
+FC := mpifort
+FFLAGS :=
+AR := ar rcs
+LD := $(FC)
+RM := rm -rf
+GD := $(SRCS_DIR)/.gen-deps.awk
+CPP := -cpp
+
+ROOT_DIR := ../../
+CONFIG_DIR := $(ROOT_DIR)/configs
+BUILD_CONFIG_FILE ?= build.conf
+include $(ROOT_DIR)/$(BUILD_CONFIG_FILE)
+include $(CONFIG_DIR)/compilers.mk
+include $(CONFIG_DIR)/flags.mk
+include $(CONFIG_DIR)/libs.mk
+ifeq ($(strip $(SINGLE_PRECISION)),1)
+DEFINES += -D_DIEZDECOMP_SINGLE
+endif
+
+BUILD_DIR := ./build
+SRC_DIR   := ./src
+OBJ_DIR   := $(BUILD_DIR)
+INC_DIR   := $(BUILD_DIR)/include
+LIB_DIR   := $(BUILD_DIR)/lib
+
+NAME := diezdecomp
+LIB := $(patsubst %, lib%.a, $(NAME))
+LIB := $(LIB_DIR)/$(LIB)
+LIB  := $(LIB_DIR)/libdiezdecomp.a
+
+SRC := $(wildcard $(SRC_DIR)/*.f90)
+
+OBJ := $(patsubst $(SRC_DIR)/%.f90,$(OBJ_DIR)/%.o,$(SRC))
+
+all: $(LIB)
+
+$(LIB): $(OBJ) | $(LIB_DIR) $(INC_DIR)
+	$(AR) $@ $^
+	cp $(BUILD_DIR)/*.mod $(INC_DIR)
+
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.f90 | $(OBJ_DIR)
+	$(FC) $(FFLAGS) $(FFLAGS_MOD_DIR)$(BUILD_DIR) $(CPP) $(DEFINES) -c $< -o $@
+
+$(OBJ_DIR)/diezdecomp_api_cans.o $(OBJ_DIR)/diezdecomp_api_generic.o: $(OBJ_DIR)/diezdecomp_core.o
+
+$(OBJ_DIR):
+	mkdir -p $@
+
+$(LIB_DIR):
+	mkdir -p $@
+
+$(INC_DIR):
+	mkdir -p $@
+
+clean:
+	$(RM) $(BUILD_DIR) *.o *.mod *.i
+
+.PHONY: all clean

--- a/dependencies/diezDecomp/src/diezdecomp_api_cans.f90
+++ b/dependencies/diezDecomp/src/diezdecomp_api_cans.f90
@@ -1,0 +1,572 @@
+module diezdecomp_api_cans
+  use mpi
+  use, intrinsic :: iso_fortran_env, only: i8 => int64, sp => real32, dp => real64
+#if defined(_OPENACC)
+  use openacc, only: acc_handle_kind
+#else
+  use, intrinsic :: iso_fortran_env, only: acc_handle_kind => int64
+#endif
+  use diezdecomp_core
+  implicit none
+#if defined(_DIEZDECOMP_SINGLE)
+  integer, parameter :: rp = sp
+  integer, parameter :: MPI_REAL_RP = MPI_REAL
+#else
+  integer, parameter :: rp = dp
+  integer, parameter :: MPI_REAL_RP = MPI_DOUBLE_PRECISION
+#endif
+
+  private
+
+  ! --------------- public variables ---------------
+  public :: diezdecompPencilInfo                    , &
+            diezdecompHandle                        , &
+            diezdecompGridDesc                      , &
+            diezdecomp_boilerplate_transpose        , &
+            diezdecomp_boilerplate_halos            , &
+            diezdecomp_get_workspace_size_transposes, &
+            diezdecomp_get_workspace_size_halos     , &
+            diezdecomp_rank_null                    , &
+            diezdecompTransposeXtoY                 , &
+            diezdecompTransposeYtoX                 , &
+            diezdecompTransposeYtoZ                 , &
+            diezdecompTransposeZtoY                 , &
+            diezdecompTransposeXtoZ                 , &
+            diezdecompTransposeZtoX                 , &
+            diezdecompUpdateHalosX                  , &
+            diezdecompUpdateHalosY                  , &
+            diezdecompUpdateHalosZ                  , &
+            diezdecompGetShiftedRank                , &
+            diezdecompGridDescCreate                , &
+            diezdecomp_halo_mpi_mode                , &
+            diezdecompGetPencilInfo                 , &
+            diezdecomp_autotune_mode_trials         , &
+            diezdecomp_n_warmup                     , &
+            diezdecomp_halo_autotuned_pack          , &
+            diezdecomp_allow_autotune_reorder       , &
+            diezdecomp_summary_halo_autotuning      , &
+            diezdecomp_summary_transp_autotuning
+
+  ! these parameters can be changed to control internal behavior (beyond the API)
+  integer, save            :: diezdecomp_rank_null              = -1
+  logical, save            :: diezdecomp_enable_alltoallv       = .false.
+  integer, save            :: diezdecomp_halo_mpi_mode          = 2
+  integer, save            :: diezdecomp_halo_autotuned_pack    = 2
+  logical, save            :: diezdecomp_allow_autotune_reorder = .false.
+
+  ! --------------- types ---------------
+  type diezdecompPencilInfo
+    integer              :: lo(3), hi(3), shape(3), internal_order(3), internal_invorder(3), pidx(2), order_halo(3), &
+                            shape_mpi_ranks(3), size, offset6(0:2,0:1)
+    logical              :: is_bound(0:1,3)
+    integer, allocatable :: mpi_ranks(:,:,:), flat_mpi_ranks(:,:)
+  end type
+
+  type diezdecompHandle
+    logical :: placeholder ! might be used later
+  end type
+
+  type diezdecompGridDesc
+    type(diezdecompPencilInfo)    :: all_ap(0:2)
+    integer                       :: irank, nproc
+    type(diezdecomp_props_transp) :: obj_tr(0:2,0:2)
+    integer                       :: abs_reorder(0:2,0:2,0:2) = -1
+  end type
+
+  contains
+
+  ! ---------------------------------------- transpose halos -------------------------------------------
+  function diezdecompTransposeXtoY(ch,gd,pa,pb,work,dtype,&
+                                   input_halo_extents, output_halo_extents, input_padding, output_padding, stream) result(ierr)
+    implicit none
+    type(diezdecompHandle)             :: ch
+    integer                            :: dtype, ierr, i_halo(0:2),o_halo(0:2),i_pad(0:2),o_pad(0:2)
+    type(diezdecompGridDesc)           :: gd
+    real(rp)                           :: pa(:,:,:), pb(:,:,:), work(:)
+    integer(acc_handle_kind), optional :: stream
+    integer(acc_handle_kind)           :: stream_internal
+    integer, optional                  :: input_halo_extents(0:2)  ,&
+                                          output_halo_extents(0:2) ,&
+                                          input_padding(0:2)       ,&
+                                          output_padding(0:2)
+    logical                            :: is_device_synchronize
+    stream_internal       = diezdecomp_stream_default
+    is_device_synchronize = (.not.present(stream))
+    if (present(stream)) stream_internal = stream
+    if (present(input_halo_extents )) then ; i_halo = input_halo_extents  ; else ; i_halo = -1 ; end if
+    if (present(output_halo_extents)) then ; o_halo = output_halo_extents ; else ; o_halo = -1 ; end if
+    if (present(input_padding      )) then ; i_pad  = input_padding       ; else ; i_pad  = -1 ; end if
+    if (present(output_padding     )) then ; o_pad  = output_padding      ; else ; o_pad  = -1 ; end if
+    call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 0, 1, diezdecomp_enable_alltoallv, stream_internal, &
+                                          is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
+    ierr = 0
+  end function
+
+  function diezdecompTransposeYtoX(ch,gd,pa,pb,work,dtype,&
+                                   input_halo_extents, output_halo_extents, input_padding, output_padding, stream) result(ierr)
+    implicit none
+    type(diezdecompHandle)             :: ch
+    integer                            :: dtype, ierr, i_halo(0:2),o_halo(0:2),i_pad(0:2),o_pad(0:2)
+    type(diezdecompGridDesc)           :: gd
+    real(rp)                           :: pa(:,:,:), pb(:,:,:), work(:)
+    integer(acc_handle_kind), optional :: stream
+    integer(acc_handle_kind)           :: stream_internal
+    integer, optional                  :: input_halo_extents(0:2)  ,&
+                                          output_halo_extents(0:2) ,&
+                                          input_padding(0:2)       ,&
+                                          output_padding(0:2)
+    logical                            :: is_device_synchronize
+    stream_internal       = diezdecomp_stream_default
+    is_device_synchronize = (.not.present(stream))
+    if (present(stream)) stream_internal = stream
+    if (present(input_halo_extents )) then ; i_halo = input_halo_extents  ; else ; i_halo = -1 ; end if
+    if (present(output_halo_extents)) then ; o_halo = output_halo_extents ; else ; o_halo = -1 ; end if
+    if (present(input_padding      )) then ; i_pad  = input_padding       ; else ; i_pad  = -1 ; end if
+    if (present(output_padding     )) then ; o_pad  = output_padding      ; else ; o_pad  = -1 ; end if
+    call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 1, 0, diezdecomp_enable_alltoallv, stream_internal, &
+                                          is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
+    ierr = 0
+  end function
+
+  function diezdecompTransposeYtoZ(ch,gd,pa,pb,work,dtype,&
+                                   input_halo_extents, output_halo_extents, input_padding, output_padding, stream) result(ierr)
+    implicit none
+    type(diezdecompHandle)             :: ch
+    integer                            :: dtype, ierr, i_halo(0:2),o_halo(0:2),i_pad(0:2),o_pad(0:2)
+    type(diezdecompGridDesc)           :: gd
+    real(rp)                           :: pa(:,:,:), pb(:,:,:), work(:)
+    integer(acc_handle_kind), optional :: stream
+    integer(acc_handle_kind)           :: stream_internal
+    integer, optional                  :: input_halo_extents(0:2)  ,&
+                                          output_halo_extents(0:2) ,&
+                                          input_padding(0:2)       ,&
+                                          output_padding(0:2)
+    logical                            :: is_device_synchronize
+    stream_internal       = diezdecomp_stream_default
+    is_device_synchronize = (.not.present(stream))
+    if (present(stream)) stream_internal = stream
+    if (present(input_halo_extents )) then ; i_halo = input_halo_extents  ; else ; i_halo = -1 ; end if
+    if (present(output_halo_extents)) then ; o_halo = output_halo_extents ; else ; o_halo = -1 ; end if
+    if (present(input_padding      )) then ; i_pad  = input_padding       ; else ; i_pad  = -1 ; end if
+    if (present(output_padding     )) then ; o_pad  = output_padding      ; else ; o_pad  = -1 ; end if
+    call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 1, 2, diezdecomp_enable_alltoallv, stream_internal, &
+                                          is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
+    ierr = 0
+  end function
+
+  function diezdecompTransposeZtoY(ch,gd,pa,pb,work,dtype,&
+                                   input_halo_extents, output_halo_extents, input_padding, output_padding, stream) result(ierr)
+    implicit none
+    type(diezdecompHandle)             :: ch
+    integer                            :: dtype, ierr, i_halo(0:2),o_halo(0:2),i_pad(0:2),o_pad(0:2)
+    type(diezdecompGridDesc)           :: gd
+    real(rp)                           :: pa(:,:,:), pb(:,:,:), work(:)
+    integer(acc_handle_kind), optional :: stream
+    integer(acc_handle_kind)           :: stream_internal
+    integer, optional                  :: input_halo_extents(0:2)  ,&
+                                          output_halo_extents(0:2) ,&
+                                          input_padding(0:2)       ,&
+                                          output_padding(0:2)
+    logical                            :: is_device_synchronize
+    stream_internal       = diezdecomp_stream_default
+    is_device_synchronize = (.not.present(stream))
+    if (present(stream)) stream_internal = stream
+    if (present(input_halo_extents )) then ; i_halo = input_halo_extents  ; else ; i_halo = -1 ; end if
+    if (present(output_halo_extents)) then ; o_halo = output_halo_extents ; else ; o_halo = -1 ; end if
+    if (present(input_padding      )) then ; i_pad  = input_padding       ; else ; i_pad  = -1 ; end if
+    if (present(output_padding     )) then ; o_pad  = output_padding      ; else ; o_pad  = -1 ; end if
+    call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 2, 1, diezdecomp_enable_alltoallv, stream_internal, &
+                                          is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
+    ierr = 0
+  end function
+
+  function diezdecompTransposeXtoZ(ch,gd,pa,pb,work,dtype,&
+                                   input_halo_extents, output_halo_extents, input_padding, output_padding, stream) result(ierr)
+    implicit none
+    type(diezdecompHandle)             :: ch
+    integer                            :: dtype, ierr, i_halo(0:2),o_halo(0:2),i_pad(0:2),o_pad(0:2)
+    type(diezdecompGridDesc)           :: gd
+    real(rp)                           :: pa(:,:,:), pb(:,:,:), work(:)
+    integer(acc_handle_kind), optional :: stream
+    integer(acc_handle_kind)           :: stream_internal
+    integer, optional                  :: input_halo_extents(0:2)  ,&
+                                          output_halo_extents(0:2) ,&
+                                          input_padding(0:2)       ,&
+                                          output_padding(0:2)
+    logical                            :: is_device_synchronize
+    stream_internal       = diezdecomp_stream_default
+    is_device_synchronize = (.not.present(stream))
+    if (present(stream)) stream_internal = stream
+    if (present(input_halo_extents )) then ; i_halo = input_halo_extents  ; else ; i_halo = -1 ; end if
+    if (present(output_halo_extents)) then ; o_halo = output_halo_extents ; else ; o_halo = -1 ; end if
+    if (present(input_padding      )) then ; i_pad  = input_padding       ; else ; i_pad  = -1 ; end if
+    if (present(output_padding     )) then ; o_pad  = output_padding      ; else ; o_pad  = -1 ; end if
+    call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 0, 2,.false., stream_internal, &
+                                          is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
+    ierr = 0
+  end function
+
+  function diezdecompTransposeZtoX(ch,gd,pa,pb,work,dtype,&
+                                   input_halo_extents, output_halo_extents, input_padding, output_padding, stream) result(ierr)
+    implicit none
+    type(diezdecompHandle)             :: ch
+    integer                            :: dtype, ierr, i_halo(0:2),o_halo(0:2),i_pad(0:2),o_pad(0:2)
+    type(diezdecompGridDesc)           :: gd
+    real(rp)                           :: pa(:,:,:), pb(:,:,:), work(:)
+    integer(acc_handle_kind), optional :: stream
+    integer(acc_handle_kind)           :: stream_internal
+    integer, optional                  :: input_halo_extents(0:2)  ,&
+                                          output_halo_extents(0:2) ,&
+                                          input_padding(0:2)       ,&
+                                          output_padding(0:2)
+    logical                            :: is_device_synchronize
+    stream_internal       = diezdecomp_stream_default
+    is_device_synchronize = (.not.present(stream))
+    if (present(stream)) stream_internal = stream
+    if (present(input_halo_extents )) then ; i_halo = input_halo_extents  ; else ; i_halo = -1 ; end if
+    if (present(output_halo_extents)) then ; o_halo = output_halo_extents ; else ; o_halo = -1 ; end if
+    if (present(input_padding      )) then ; i_pad  = input_padding       ; else ; i_pad  = -1 ; end if
+    if (present(output_padding     )) then ; o_pad  = output_padding      ; else ; o_pad  = -1 ; end if
+    call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 2, 0,.false., stream_internal, &
+                                          is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
+    ierr = 0
+  end function
+
+  ! ---------------------------------------- api halos -------------------------------------------
+  function diezdecompUpdateHalosX(ch,gd,p,work,dtype,nh_xyz,periods,ii,offset6_orig, stream) result(ierr)
+    implicit none
+    type(diezdecompHandle)             :: ch
+    type(diezdecompGridDesc)           :: gd
+    real(rp), contiguous               :: p(:,:,:), work(:)
+    integer                            :: dtype, nh_xyz(3), ii, ierr,offset6(0:2,0:1)
+    logical                            :: periods(3)
+    integer(acc_handle_kind), optional :: stream
+    integer(acc_handle_kind)           :: stream_internal
+    logical                            :: is_device_synchronize
+    integer, optional                  :: offset6_orig(0:2,0:1)
+    if (present(offset6_orig)) then  ; offset6 =  offset6_orig
+    else                             ; offset6 = 0                 ; end if
+    stream_internal       = diezdecomp_stream_default
+    is_device_synchronize = (.not.present(stream))
+    if (present(stream)) stream_internal = stream
+    call diezdecomp_boilerplate_halos(gd, p, work, nh_xyz, offset6, periods, ii, 1, stream_internal, is_device_synchronize)
+    ierr = 0
+  end function
+
+  function diezdecompUpdateHalosY(ch,gd,p,work,dtype,nh_xyz,periods,ii,offset6_orig, stream) result(ierr)
+    implicit none
+    type(diezdecompHandle)             :: ch
+    type(diezdecompGridDesc)           :: gd
+    real(rp), contiguous               :: p(:,:,:), work(:)
+    integer                            :: dtype, nh_xyz(3), ii, ierr,offset6(0:2,0:1)
+    logical                            :: periods(3)
+    integer(acc_handle_kind), optional :: stream
+    integer(acc_handle_kind)           :: stream_internal
+    logical                            :: is_device_synchronize
+    integer, optional                  :: offset6_orig(0:2,0:1)
+    if (present(offset6_orig)) then  ; offset6 =  offset6_orig
+    else                             ; offset6 = 0                 ; end if
+    stream_internal       = diezdecomp_stream_default
+    is_device_synchronize = (.not.present(stream))
+    if (present(stream)) stream_internal = stream
+    call diezdecomp_boilerplate_halos(gd, p, work, nh_xyz, offset6, periods, ii, 2, stream_internal, is_device_synchronize)
+    ierr = 0
+  end function
+
+  function diezdecompUpdateHalosZ(ch,gd,p,work,dtype,nh_xyz,periods,ii,offset6_orig, stream) result(ierr)
+    implicit none
+    type(diezdecompHandle)             :: ch
+    type(diezdecompGridDesc)           :: gd
+    real(rp), contiguous               :: p(:,:,:), work(:)
+    integer                            :: dtype, nh_xyz(3), ii, ierr,offset6(0:2,0:1)
+    logical                            :: periods(3)
+    integer(acc_handle_kind), optional :: stream
+    integer(acc_handle_kind)           :: stream_internal
+    logical                            :: is_device_synchronize
+    integer, optional                  :: offset6_orig(0:2,0:1)
+    if (present(offset6_orig)) then  ; offset6 =  offset6_orig
+    else                             ; offset6 = 0                 ; end if
+    stream_internal       = diezdecomp_stream_default
+    is_device_synchronize = (.not.present(stream))
+    if (present(stream)) stream_internal = stream
+    call diezdecomp_boilerplate_halos(gd, p, work, nh_xyz, offset6, periods, ii, 3, stream_internal, is_device_synchronize)
+    ierr = 0
+  end function
+
+  ! ---------------------------------------- diezdecomp size calculation -------------------------------------------
+  function diezdecomp_get_workspace_size_halos(ch,gd,ipencil,nh_xyz,wsize) result(ierr)
+    implicit none
+    type(diezdecompHandle)   :: ch
+    type(diezdecompGridDesc) :: gd
+    integer(i8)              :: wsize
+    integer                  :: ii, jj, kk, side_numel, ipencil, nh_xyz(0:2), internal_order(0:2),ierr
+    ierr  = 0
+    wsize = 1
+    do ii=0,2
+      if      (ii == 0) then ; jj = 1; kk = 2
+      else if (ii == 1) then ; jj = 0; kk = 2
+      else if (ii == 2) then ; jj = 0; kk = 1 ; end if
+      internal_order(0:2) =  gd%all_ap(ipencil-1)%internal_order(1:3)
+      side_numel          = (gd%all_ap(ipencil-1)%shape(diezdecomp_get_index_int2int(internal_order,jj)+1) + 2*nh_xyz(jj))* &
+                            (gd%all_ap(ipencil-1)%shape(diezdecomp_get_index_int2int(internal_order,kk)+1) + 2*nh_xyz(kk))* &
+                            nh_xyz(ii)
+      wsize               = max(wsize, int(4*side_numel,i8))
+    end do
+  ierr = 0
+  end function
+
+  function diezdecomp_get_workspace_size_transposes(ch, gd, wsize) result(ierr)
+    implicit none
+    type(diezdecompHandle)   :: ch
+    type(diezdecompGridDesc) :: gd
+    integer(i8)              :: wsize, sx, sz, sy
+    integer                  :: ierr
+    ierr  = 0
+    wsize = 1
+    sx    = int(gd%all_ap(0)%size,i8)
+    sy    = int(gd%all_ap(1)%size,i8)
+    sz    = int(gd%all_ap(2)%size,i8)
+    wsize = max(wsize, sx+sy, sx+sz, sy+sz)
+  end function
+
+  ! ---------------------------------------- boilerplate transpose/halos -------------------------------------------
+  subroutine diezdecomp_boilerplate_transpose(gd, p_in, p_out, work, ii, jj, &
+                                              allow_alltoallv, stream, is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
+    implicit none
+    type(diezdecompGridDesc) :: gd
+    real(rp)                 :: p_in(:,:,:), p_out(:,:,:), work(:)
+    integer                  :: ii, jj, kk, ii_jj_kk(0:2), abs_reorder(0:2), &
+                                offset6_in(0:2,0:1), offset6_out(0:2,0:1), i_halo(0:2), o_halo(0:2), i_pad(0:2), o_pad(0:2), &
+                                zeros6(0:2,0:1)
+    logical                  :: allow_alltoallv, is_device_synchronize
+    integer(acc_handle_kind) :: stream
+    if (.not.(gd%obj_tr(ii,jj)%initialized)) then
+      kk       = 3 - ii - jj
+      ii_jj_kk = [ii,jj,kk]
+      zeros6   = 0
+      abs_reorder = gd%abs_reorder(ii,jj,:)
+      call diezdecomp_fill_transp_props(gd%obj_tr(ii,jj)                            , &
+                                        abs_reorder                                 , &
+                                        gd%all_ap(ii)%internal_order                , &
+                                        gd%all_ap(jj)%internal_order                , &
+                                        gd%all_ap(ii)%lo - 1, gd%all_ap(ii)%hi - 1  , &
+                                        gd%all_ap(jj)%lo - 1, gd%all_ap(jj)%hi - 1  , &
+                                        ii_jj_kk                                    , &
+                                        gd%irank, gd%nproc,allow_alltoallv          , &
+                                        gd%all_ap(ii)%shape, zeros6                 , &
+                                        gd%all_ap(jj)%shape, zeros6                 , &
+                                        diezdecomp_allow_autotune_reorder, stream   )
+    end if
+    offset6_in  = gd%obj_tr(ii,jj)%offset6_in
+    offset6_out = gd%obj_tr(ii,jj)%offset6_out
+    if ((i_halo(0)>=0).and.(i_pad(0)>=0)) then
+      gd%obj_tr(ii,jj)%offset6_in(:,0)  =  i_halo
+      gd%obj_tr(ii,jj)%offset6_in(:,1)  =  i_halo + i_pad
+    end if
+    if ((o_halo(0)>=0).and.(o_pad(0)>=0)) then
+      gd%obj_tr(ii,jj)%offset6_out(:,0)  =  o_halo
+      gd%obj_tr(ii,jj)%offset6_out(:,1)  =  o_halo + o_pad
+    end if
+    call diezdecomp_transp_execute(gd%obj_tr(ii,jj), p_in, p_out, stream, work)
+    gd%obj_tr(ii,jj)%offset6_in  = offset6_in
+    gd%obj_tr(ii,jj)%offset6_out = offset6_out
+    if (is_device_synchronize) then
+      !$acc wait(stream)
+    end if
+  end subroutine
+
+  subroutine diezdecomp_boilerplate_halos(gd, p, work, nh_xyz, offset6, periods, ii, axis, stream, is_device_synchronize, &
+                                          print_summary)
+    implicit none
+    type(diezdecompGridDesc)    :: gd
+    real(rp)                    :: p(:,:,:), work(:)
+    integer                     :: nh_xyz(3), ii, axis, p_shape(0:2), offset6(0:2,0:1)
+    logical                     :: periods(3), is_per, is_device_synchronize
+    logical, optional           :: print_summary
+    type(diezdecomp_props_halo) :: this
+    integer(acc_handle_kind)    :: stream
+    ! call check_bounds(ii  , 1, 3)
+    ! call check_bounds(axis, 1, 3)
+
+    if (.not.(this%initialized)) then
+      is_per  = periods(ii)
+      p_shape = [size(p,1), size(p,2), size(p,3)]
+      if (axis==0) error stop 'ERROR: axis out-of-scope' ! , axis
+      call diezdecomp_fill_halo_props(this, ii-1, is_per, &
+                                      gd%all_ap(axis-1)%mpi_ranks, &
+                                      gd%all_ap(axis-1)%flat_mpi_ranks, &
+                                      gd%all_ap(axis-1)%shape_mpi_ranks, &
+                                      nh_xyz, gd%all_ap(axis-1)%order_halo, &
+                                      p_shape, offset6, gd%irank, gd%nproc, diezdecomp_halo_mpi_mode, &
+                                      diezdecomp_halo_autotuned_pack)
+    end if
+    call diezdecomp_halos_execute(this, p, work, stream)
+    if (is_device_synchronize) then
+      !$acc wait(stream)
+    end if
+    if (present(print_summary)) then
+      if (print_summary) call diezdecomp_summary_halo_autotuning(this)
+    end if
+  end subroutine
+
+  ! ---------------------------------------- diezdecomp wrappers ---------------------------------------------
+  subroutine diezdecompGridDescCreate(gd, pdims, gdims, gdims_dist, transpose_axis_contiguous, periods, ipencil, offset6_xyz_orig)
+    implicit none
+    type(diezdecompGridDesc) :: gd
+    integer                  :: pdims(0:1), gdims(0:2), gdims_dist(0:2), ipencil, axis, mpi_ierr, offset6_xyz(0:2,0:1)
+    integer, optional        :: offset6_xyz_orig(0:2,0:1)
+    logical                  :: transpose_axis_contiguous(0:2)
+    logical                  :: periods(3)
+    if (present(offset6_xyz_orig)) then  ; offset6_xyz =  offset6_xyz_orig
+    else                                 ; offset6_xyz = 0                 ; end if
+    ! call check_bounds(ipencil, 1, 3, 103)
+
+    call mpi_comm_rank(mpi_comm_world, gd%irank, mpi_ierr)
+    call mpi_comm_size(mpi_comm_world, gd%nproc, mpi_ierr)
+    do axis=0,2
+      call summary_cudecompGetPencilInfo(gd%all_ap(axis), axis, pdims, gdims, gdims_dist, transpose_axis_contiguous, periods, &
+                                        ipencil, offset6_xyz, gd%irank, gd%nproc)
+    end do
+    block 
+      integer :: i,j,k
+      do     i=0,2
+        do   j=0,2
+          do k=0,2
+            ! default initialization: gd%abs_reorder matches output "internal_order"
+            gd%abs_reorder(i,j,k) = gd%all_ap(j)%internal_order(k+1)
+          end do 
+        end do 
+      end do 
+    end block 
+  end subroutine
+
+  function diezdecompGetPencilInfo(ch, gd ,ap, axis)  result(ierr)
+    implicit none
+    type(diezdecompHandle)   :: ch
+    type(diezdecompGridDesc) :: gd
+    type(diezdecompPencilInfo) :: ap
+    integer                  :: axis, ierr
+    ! call check_bounds(axis, 1, 3, 121)
+    ap = gd%all_ap(axis-1)
+    ierr = 0
+  end function
+
+  function diezdecompGetShiftedRank(ch, gd, axis, dim, d, is_per, nb_val)  result(ierr)
+    implicit none
+    type(diezdecompHandle)   :: ch
+    type(diezdecompGridDesc) :: gd
+    integer                  :: axis, dim, d, nb_val, ierr
+    logical                  :: is_per
+    ! call check_bounds(axis,  1, 3, 131)
+    ! call check_bounds(dim ,  1, 3, 132)
+    ! call check_bounds(d   , -1, 1, 133)
+    if (gd%all_ap(axis-1)%is_bound(max(0,d),dim)) then
+      nb_val = diezdecomp_rank_null
+    else
+      nb_val = diezdecomp_get_rank_id(gd%all_ap(axis-1)%mpi_ranks, &
+                                      gd%all_ap(axis-1)%flat_mpi_ranks, &
+                                      gd%all_ap(axis-1)%shape_mpi_ranks, gd%irank, dim-1, d)
+    endif
+    ierr = 0
+  end function
+
+  subroutine diezdecomp_fill_is_bound(this, flat_mpi_ranks, shape_mpi_ranks, periods, ipencil, irank)
+    implicit none
+    type(diezdecompPencilInfo) :: this
+    integer                  :: irank, i0, j0, k0, i, ind, ipencil
+    integer                  :: shape_mpi_ranks(0:2), flat_mpi_ranks(0:,0:)
+    logical                  :: periods(3)
+
+    ! call check_bounds(ipencil, 1, 3)
+    i0 = flat_mpi_ranks(irank,0) + 1
+    j0 = flat_mpi_ranks(irank,1) + 1
+    k0 = flat_mpi_ranks(irank,2) + 1
+
+    this%is_bound(:,:) = .false.
+    do i=1,3
+      if (i==1) ind = i0
+      if (i==2) ind = j0
+      if (i==3) ind = k0
+      if (.not.periods(i)) then
+        if (ind == 1                   ) this%is_bound(0,i) = .true.
+        if (ind == shape_mpi_ranks(i-1)) this%is_bound(1,i) = .true.
+      end if
+      if (i == ipencil) then
+        this%is_bound(0,i) = .true.
+        this%is_bound(1,i) = .true.
+      end if
+    end do
+  end subroutine
+
+  ! ---------------------------------------- ported routines -------------------------------------------
+  subroutine summary_cudecompGetPencilInfo(this, axis, pdims, gdims, gdims_dist, transpose_axis_contiguous, periods, ipencil, &
+                                          offset6_xyz, irank, nproc)
+    !  (Needed for compatibility with CaNS)
+    !  Summary of external behavior in:
+    !    cuDecomp: An Adaptive Pencil Decomposition Library for NVIDIA GPUs
+    !    https://github.com/NVIDIA/cuDecomp/blob/main/src/cudecomp.cc
+    implicit none
+    integer                  :: lo(0:2), hi(0:2), shape(0:2), order(0:2), invorder(0:2), pidx(0:1), &
+                                axis, pdims(0:1), gdims(0:2), gdims_dist(0:2), offset6_xyz(0:2,0:1)
+    logical                  :: transpose_axis_contiguous(0:2)
+    integer                  :: i,j,k,d,odd,irank,nproc
+    type(diezdecompPencilInfo) :: this
+    ! last 3 arguments (used at the end of this routine for simplicity)
+    integer                  :: ipencil
+    logical                  :: periods(3)
+
+    ! call check_bounds(axis   , 0,       2)
+    ! call check_bounds(ipencil, 1,       3)
+    ! call check_bounds(irank  , 0, nproc-1)
+
+    pidx(0) = irank / pdims(1)
+    pidx(1) = mod(irank, pdims(1))
+
+    do i=0,2
+      if (transpose_axis_contiguous(axis)) then
+        order(i) = mod(axis + i, 3)
+      else
+        order(i) = i
+      endif
+        invorder(order(i)) = i
+      end do
+    j = 0
+    do i=0,2
+      k = invorder(i)
+      if (i /= axis) then
+        d   = gdims_dist(i) / pdims(j)
+        odd = mod(gdims_dist(i), pdims(j))
+        shape(k) = d
+        if (pidx(j) < odd)                               shape(k) = shape(k) + 1
+        if (pidx(j) == min(pdims(j), gdims_dist(i)) - 1) shape(k) = shape(k) + gdims(i) - gdims_dist(i)
+        lo(k) = pidx(j) * d + min(pidx(j), odd)
+        j       = j + 1
+      else
+        shape(k) = gdims(i)
+        lo(k)    = 0
+      end if
+      hi(k)      = lo(k) + shape(k) - 1
+    end do
+    ! copy data (with shift)
+    do i=0,2
+      this%lo               (i+1) = lo      (i) + 1
+      this%hi               (i+1) = hi      (i) + 1
+      this%shape            (i+1) = shape   (i)
+      this%internal_order   (i+1) = order   (i)
+      this%internal_invorder(i+1) = invorder(i)
+    end do
+    this%pidx(1) = pidx(0)
+    this%pidx(2) = pidx(1)
+    ! ------ diezDecomp objects ------
+    ! fill is_bound and mpi_ranks
+    call diezdecomp_fill_mpi_ranks([lo(invorder(0)), lo(invorder(1)), lo(invorder(2))], &
+                                   this%mpi_ranks, this%flat_mpi_ranks, this%shape_mpi_ranks, irank, nproc)
+    call diezdecomp_fill_is_bound(this, this%flat_mpi_ranks, this%shape_mpi_ranks, periods, ipencil, irank)
+    this%order_halo = [0, 1, 2]
+    this%size       = product(this%shape)
+    do i=0,2
+      this%offset6(i,:) = offset6_xyz(order(i),:)
+    end do
+  end subroutine
+
+end module

--- a/dependencies/diezDecomp/src/diezdecomp_api_generic.f90
+++ b/dependencies/diezDecomp/src/diezdecomp_api_generic.f90
@@ -1,0 +1,265 @@
+module diezdecomp_api_generic
+  use mpi
+  use, intrinsic :: iso_fortran_env, only: i8 => int64, sp => real32, dp => real64
+#if defined(_OPENACC)
+  use openacc, only: acc_handle_kind
+#else
+  use, intrinsic :: iso_fortran_env, only: acc_handle_kind => int64
+#endif
+  use diezdecomp_core
+  implicit none
+#if defined(_DIEZDECOMP_SINGLE)
+  integer, parameter :: rp = sp
+#else
+  integer, parameter :: rp = dp
+#endif
+  real(dp), parameter :: LARGE = huge(1._dp)
+
+  private
+
+  ! --------------- public variables ---------------
+  public :: diezdecomp_generic_fill_tr_obj         , &
+            diezdecomp_generic_fill_hl_obj         , &
+            diezdecomp_track_mpi_decomp            , &
+            diezdecomp_transp_execute_generic_buf  , &
+            diezdecomp_transp_execute_generic_nobuf, &
+            diezdecomp_halos_execute_generic       , &
+            diezdecomp_props_halo                  , &
+            diezdecomp_props_transp                , &
+            diezdecomp_parsed_mpi_ranks            , &
+            diezdecomp_autotune_mode_trials        , &
+            diezdecomp_n_warmup                    , &
+            diezdecomp_summary_halo_autotuning     , &
+            diezdecomp_summary_transp_autotuning
+
+  ! --------------- types ---------------
+  type diezdecomp_parsed_mpi_ranks
+    integer              :: shape_mpi_ranks(0:2), irank, nproc
+    integer, allocatable :: mpi_ranks(:,:,:), flat_mpi_ranks(:,:)
+  end type
+
+  contains
+
+  subroutine diezdecomp_transp_execute_generic_buf(this, p_in, p_out, work, offset_3x2_in, offset_3x2_out, stream)
+    implicit none
+    type(diezdecomp_props_transp)      :: this
+    real(rp), target                   :: p_in(:,:,:), p_out(:,:,:)
+    real(rp), target                   :: work(0:)
+    integer                            ::    offset6_in(0:2,0:1),    offset6_out(0:2,0:1)
+    integer                 , optional :: offset_3x2_in(0:2,0:1), offset_3x2_out(0:2,0:1)
+    integer(acc_handle_kind), optional :: stream
+    integer(acc_handle_kind)           :: stream_internal
+    stream_internal  =  diezdecomp_stream_default
+    if (present(stream)) stream_internal = stream
+    if (present(offset_3x2_in )) then ; offset6_in  = this%offset6_in  ; this%offset6_in  = offset_3x2_in  ; end if
+    if (present(offset_3x2_out)) then ; offset6_out = this%offset6_out ; this%offset6_out = offset_3x2_out ; end if
+    call diezdecomp_transp_execute(this, p_in, p_out, stream_internal, work)
+    if (present(offset_3x2_in )) then ; this%offset6_in  = offset6_in  ; end if ! restore original offsets
+    if (present(offset_3x2_out)) then ; this%offset6_out = offset6_out ; end if
+    if (.not.present(stream)) then
+      !$acc wait(stream_internal)
+    end if
+  end subroutine
+
+  subroutine diezdecomp_transp_execute_generic_nobuf(this, p_in, p_out, offset_3x2_in, offset_3x2_out, stream)
+    implicit none
+    type(diezdecomp_props_transp)      :: this
+    real(rp), target                   :: p_in(0:*), p_out(0:*)
+    integer                            ::    offset6_in(0:2,0:1),    offset6_out(0:2,0:1)
+    integer                 , optional :: offset_3x2_in(0:2,0:1), offset_3x2_out(0:2,0:1)
+    integer(acc_handle_kind), optional :: stream
+    integer(acc_handle_kind)           :: stream_internal
+    stream_internal  =  diezdecomp_stream_default
+    if (present(stream)) stream_internal = stream
+    if (present(offset_3x2_in )) then ; offset6_in  = this%offset6_in  ; this%offset6_in  = offset_3x2_in  ; end if
+    if (present(offset_3x2_out)) then ; offset6_out = this%offset6_out ; this%offset6_out = offset_3x2_out ; end if
+    call diezdecomp_transp_execute(this, p_in, p_out, stream_internal)
+    if (present(offset_3x2_in )) then ; this%offset6_in  = offset6_in  ; end if ! restore original offsets
+    if (present(offset_3x2_out)) then ; this%offset6_out = offset6_out ; end if
+    if (.not.present(stream)) then
+      !$acc wait(stream_internal)
+    end if
+  end subroutine
+
+  subroutine diezdecomp_halos_execute_generic(this, p, work, offset3_start, stream)
+    implicit none
+    type(diezdecomp_props_halo) :: this
+    real(rp), contiguous :: p(0:,0:,0:), work(0:)
+    integer                            :: offset3(0:2)
+    integer                 , optional :: offset3_start(0:2)
+    integer(acc_handle_kind), optional :: stream
+    integer(acc_handle_kind)           :: stream_internal
+    ! note:
+    !   1) "offset3_start" are the offsets of p(0:,0:,0:) at the begging of each dimension
+    !   2) technically, knowing the offsets at the end (offset3_end) is not necessary,
+    !      because "p" is passed as a 3-D array (assumed shape is not used)
+    stream_internal  =  diezdecomp_stream_default
+    if (present(stream)) stream_internal = stream
+    if (present(offset3_start)) then ; offset3  = this%offset3  ; this%offset3  = offset3_start  ; end if
+    call diezdecomp_halos_execute(this, p, work, stream_internal)
+    if (present(offset3_start)) then ; this%offset3 = offset3  ; end if ! restore original offsets
+    if (.not.present(stream)) then
+      !$acc wait(stream_internal)
+    end if
+  end subroutine
+
+  subroutine diezdecomp_generic_fill_tr_obj(tr, obj_in, obj_out, sp_in_full, offset6_in, sp_out_full, offset6_out, &
+                                            order_in, order_out, order_intermediate, &
+                                            allow_alltoallv, ii, jj, wsize, allow_autotune_reorder, stream)
+    implicit none
+    type(diezdecomp_props_transp)      ::  tr
+    type(diezdecomp_parsed_mpi_ranks)  ::  obj_in, obj_out
+    integer(i8)                        ::  wsize
+    integer                            ::  sp_in_full(0:2), sp_out_full(0:2), &
+                                           order_in(0:2), order_out(0:2), order_intermediate(0:2), &
+                                           lo_in(0:2), hi_in(0:2), offset6_in(0:2,0:1), offset6_out(0:2,0:1), &
+                                           lo_out(0:2), hi_out(0:2), &
+                                           ii, jj, kk, ii_jj_kk(0:2)
+    logical                            ::  allow_alltoallv, allow_autotune_reorder
+    integer(acc_handle_kind), optional ::  stream
+    integer(acc_handle_kind)           ::  stream_internal
+    stream_internal = diezdecomp_stream_default
+    if (present(stream)) stream_internal = stream
+    if (.not.(tr%initialized)) then
+      block
+        integer :: sp_in(0:2), sp_out(0:2)
+        sp_in  = [sp_in_full(0)  - offset6_in(0,0)  - offset6_in(0,1)  , &
+                  sp_in_full(1)  - offset6_in(1,0)  - offset6_in(1,1)  , &
+                  sp_in_full(2)  - offset6_in(2,0)  - offset6_in(2,1)  ]
+        sp_out = [sp_out_full(0) - offset6_out(0,0) - offset6_out(0,1) , &
+                  sp_out_full(1) - offset6_out(1,0) - offset6_out(1,1) , &
+                  sp_out_full(2) - offset6_out(2,0) - offset6_out(2,1) ]
+        wsize = product(sp_in) + product(sp_out)
+        if (wsize<1) wsize=1
+        call get_lo_hi_3d(lo_in , hi_in , obj_in , sp_in , order_in )
+        call get_lo_hi_3d(lo_out, hi_out, obj_out, sp_out, order_out)
+      end block
+      kk       = 3 - ii - jj
+      ii_jj_kk = [ii,jj,kk]
+      call diezdecomp_fill_transp_props(tr                                     , &
+                                        order_intermediate                     , &
+                                        order_in                               , &
+                                        order_out                              , &
+                                        lo_in, hi_in                           , &
+                                        lo_out, hi_out                         , &
+                                        ii_jj_kk                               , &
+                                        obj_in%irank, obj_in%nproc, allow_alltoallv, &
+                                        sp_in_full , offset6_in         , &
+                                        sp_out_full, offset6_out        , &
+                                        allow_autotune_reorder, stream_internal)
+    end if
+    ! now tr is ready to call:
+    !   call diezdecomp_transp_execute_generic(tr, p_in, p_out, work, stream) ! size(work) --> wsize
+  end subroutine
+
+  subroutine diezdecomp_generic_fill_hl_obj(hl, obj_in, p_shape, offset6, ii, nh_xyz, order_halo, periodic, wsize, &
+                                            force_halo_sync, autotuned_pack)
+    implicit none
+    integer(i8)                        ::  wsize
+    type(diezdecomp_props_halo)        ::  hl
+    type(diezdecomp_parsed_mpi_ranks)  ::  obj_in
+    integer                            :: nh_xyz(0:2), ii, p_shape(0:2), order_halo(0:2), force_halo_sync, &
+                                          autotuned_pack, offset6(0:2,0:1)
+    logical                            :: periodic(0:2), is_per
+    ! call check_bounds(ii  , 0, 2)
+    if (.not.(hl%initialized)) then
+      is_per  = periodic(ii)
+      call diezdecomp_fill_halo_props(hl, ii, is_per, &
+                                      obj_in%mpi_ranks, &
+                                      obj_in%flat_mpi_ranks, &
+                                      obj_in%shape_mpi_ranks, &
+                                      nh_xyz, order_halo, &
+                                      p_shape, offset6, obj_in%irank, obj_in%nproc, force_halo_sync, autotuned_pack)
+    end if
+    block
+      integer :: jj,kk
+      if      (ii == 0) then ; jj = 1; kk = 2
+      else if (ii == 1) then ; jj = 0; kk = 2
+      else if (ii == 2) then ; jj = 0; kk = 1 ; end if
+      wsize = p_shape(diezdecomp_get_index_int2int(order_halo,jj))*p_shape(diezdecomp_get_index_int2int(order_halo,kk))*4*nh_xyz(ii)
+      if (wsize<1) wsize=1
+    end block
+    ! now hl is ready to call:
+    !   call diezdecomp_halos_execute(hl, p_in, work, stream) ! size(work) --> wsize
+  end subroutine
+
+  subroutine diezdecomp_track_mpi_decomp(lo_loc, obj_in, irank, nproc, order)
+    type(diezdecomp_parsed_mpi_ranks)  ::  obj_in
+    integer                            ::  lo_loc(0:2), lo(0:2), irank, nproc
+    integer, optional                  ::  order(0:2)
+    lo  =  lo_loc
+    if (present(order)) lo  =  [lo_loc(diezdecomp_get_index_int2int(order,0)), &
+                                lo_loc(diezdecomp_get_index_int2int(order,1)), &
+                                lo_loc(diezdecomp_get_index_int2int(order,2))]
+    obj_in%irank  =  irank
+    obj_in%nproc  =  nproc
+    call diezdecomp_fill_mpi_ranks(lo, obj_in%mpi_ranks, obj_in%flat_mpi_ranks, obj_in%shape_mpi_ranks, irank, nproc)
+  end subroutine
+
+  ! ---------------------------------------- diezdecomp utilities -------------------------------------------
+  subroutine get_lo_hi_3d(lo, hi, obj, sz3_0, order)
+    integer                          :: lo(0:2), hi(0:2), order(0:2), sz3(0:2), sz3_0(0:2), &
+                                        ii, jj, kk, ipos, iaxis, mpi_ierr
+    type(diezdecomp_parsed_mpi_ranks):: obj
+    integer, allocatable             :: buf_flat(:), buf_3d(:,:,:)
+
+    sz3 = [sz3_0(diezdecomp_get_index_int2int(order,0)), &
+           sz3_0(diezdecomp_get_index_int2int(order,1)), &
+           sz3_0(diezdecomp_get_index_int2int(order,2))]
+
+    allocate(buf_3d(0:obj%shape_mpi_ranks(0)-1, &
+                    0:obj%shape_mpi_ranks(1)-1, &
+                    0:obj%shape_mpi_ranks(2)-1), &
+             buf_flat(0:(3*obj%nproc-1)))
+    call MPI_Allgather(sz3, 3, mpi_int, buf_flat, 3, mpi_int, mpi_comm_world, mpi_ierr)
+    do   iaxis = 0, 2
+      block
+        integer :: i,j,k
+        do ipos  = 0, obj%nproc-1
+          i = obj%flat_mpi_ranks(ipos,0)
+          j = obj%flat_mpi_ranks(ipos,1)
+          k = obj%flat_mpi_ranks(ipos,2)
+          buf_3d(i,j,k) = buf_flat(3*ipos+iaxis)
+        end do
+      end block
+      ii = obj%flat_mpi_ranks(obj%irank,0)
+      jj = obj%flat_mpi_ranks(obj%irank,1)
+      kk = obj%flat_mpi_ranks(obj%irank,2)
+      lo(iaxis) = 0
+      hi(iaxis) = 0
+      if      (iaxis == 0) then
+        block
+          integer :: i
+          do i=0,ii
+            lo(iaxis) = hi(iaxis)
+            hi(iaxis) = hi(iaxis) + buf_3d(i,jj,kk)
+          end do
+        end block
+      else if (iaxis == 1) then
+        block
+          integer :: j
+          do j=0,jj
+            lo(iaxis) = hi(iaxis)
+            hi(iaxis) = hi(iaxis) + buf_3d(ii,j,kk)
+          end do
+        end block
+      else if (iaxis == 2) then
+        block
+          integer :: k
+          do k=0,kk
+            lo(iaxis) = hi(iaxis)
+            hi(iaxis) = hi(iaxis) + buf_3d(ii,jj,k)
+          end do
+        end block
+      end if
+    end do
+    hi = hi - 1
+    deallocate(buf_3d, buf_flat)
+    block
+      integer :: A(0:2)
+      A(0:2) = lo(0:2) ; lo = [A(order(0)), A(order(1)), A(order(2))]
+      A(0:2) = hi(0:2) ; hi = [A(order(0)), A(order(1)), A(order(2))]
+    end block
+  end subroutine
+
+end module

--- a/dependencies/diezDecomp/src/diezdecomp_core.f90
+++ b/dependencies/diezDecomp/src/diezdecomp_core.f90
@@ -1,0 +1,2151 @@
+module diezdecomp_core
+  use mpi
+! #if defined(_DIEZDECOMP_NCCL)
+!   use nccl
+! #endif
+  use, intrinsic :: iso_fortran_env, only: i8 => int64, sp => real32, dp => real64
+  use, intrinsic :: iso_c_binding  , only: c_loc,c_size_t
+#if defined(_OPENACC)
+  use openacc, only: acc_handle_kind
+#else
+  use, intrinsic :: iso_fortran_env, only: acc_handle_kind => int64
+#endif
+  implicit none
+#if defined(_DIEZDECOMP_SINGLE)
+  integer, parameter :: rp = sp
+  integer, parameter :: MPI_REAL_RP = MPI_REAL
+#else
+  integer, parameter :: rp = dp
+  integer, parameter :: MPI_REAL_RP = MPI_DOUBLE_PRECISION
+#endif
+  real(dp), parameter            :: LARGE = huge(1._dp)
+  integer(acc_handle_kind), save :: diezdecomp_stream_default = 1
+  logical, save                  :: diezdecomp_mode_bench_avg = .false.
+  private
+
+  ! --------------- public variables ---------------
+  public :: diezdecomp_props_halo              , &
+            diezdecomp_props_transp            , &
+            diezdecomp_fill_halo_props         , &
+            diezdecomp_fill_transp_props       , &
+            diezdecomp_halos_execute           , &
+            diezdecomp_transp_execute          , &
+            diezdecomp_fill_mpi_ranks          , &
+            diezdecomp_get_index_int2int       , &
+            diezdecomp_get_rank_id             , &
+            diezdecomp_stream_default          , &
+            diezdecomp_autotune_mode_trials    , &
+            diezdecomp_n_warmup                , &
+            diezdecomp_summary_halo_autotuning , &
+            diezdecomp_summary_transp_autotuning
+
+! #if defined(_DIEZDECOMP_NCCL)
+!   type(ncclUniqueId)       , save :: nccl_id
+!   type(ncclResult)         , save :: nccl_stat
+!   type(ncclComm)           , save :: nccl_comm
+!   logical                  , save :: nccl_is_init = .false.
+!   integer(cuda_stream_kind), save :: nccl_stream
+! #endif
+
+  integer, save :: diezdecomp_autotune_mode_trials = 20
+  integer, save :: diezdecomp_n_warmup             = 3
+
+  ! --------------- types ---------------
+
+  type diezdecomp_props_halo
+    logical :: args_active(0:1)
+    integer :: irank, loc_shape(0:2), nh_ijk(0:2), side_numel, nh_dir, dir_pick  , &
+               args_other_id(0:1), args_inds_recv_i0(0:1), args_inds_recv_i1(0:1), &
+                                   args_inds_send_i0(0:1), args_inds_send_i1(0:1), &
+               args_tag_send(0:1), args_tag_recv(0:1), &
+               args_pos_send(0:1), args_pos_recv(0:1), args_rel_pos_align, &
+               all_request(0:3), all_status(MPI_STATUS_SIZE,0:3), autotuned_pack, &
+               offset3(0:2), halo_mpi_mode, nproc
+    logical :: initialized = .false.
+    real(rp) :: elapsed_sendrecv, elapsed_isendirecv, wtime_2, wtime_3
+  end type
+
+  type diezdecomp_props_transp
+    integer              :: irank, nproc, mpi_comm_kk, irank_comm_kk, &
+                            size_localSend, size_localRecv, pos_start_localSend, pos_start_localRecv, &
+                            send_mode_op_batched, send_mode_op_simul, send_autotuned , send_i2b_Mij(0:2,0:2), &
+                            recv_mode_op_batched, recv_mode_op_simul, recv_autotuned , recv_i2b_Mij(0:2,0:2), &
+                            best_recv_mode_op_simul(0:5), best_recv_autotuned(0:5), best_recv_mode_op_batched(0:5), &
+                            best_send_mode_op_simul(0:5), best_send_autotuned(0:5), best_send_mode_op_batched(0:5), &
+                            sp_in_0, sp_in_1, sp_in_2, sp_out_0, sp_out_1, sp_out_2, order_a(0:2), order_b(0:2),&
+                            offset6_in(0:2,0:1), offset6_out(0:2,0:1), &
+                            numel_p_in, numel_p_out, chosen_reorder(0:2), reorder_ijk(0:2,0:5)
+    integer, allocatable :: send_ids(:), send_sizes(:), send_tags(:), send_pos_start(:), &
+                            recv_ids(:), recv_sizes(:), recv_tags(:), recv_pos_start(:), &
+                            send_i0_st(:), send_i1_st(:), send_i2_st(:), send_lshape(:,:), &
+                            recv_i0_st(:), recv_i1_st(:), recv_i2_st(:), recv_lshape(:,:), &
+                            send_b_i0(:), send_b_i1(:), send_b_i2(:), &
+                            recv_b_i0(:), recv_b_i1(:), recv_b_i2(:), &
+                            send_all_n0(:,:,:), send_all_n1(:,:,:), send_all_n2(:,:,:), send_all_pos_start(:,:,:),&
+                            recv_all_n0(:,:,:), recv_all_n1(:,:,:), recv_all_n2(:,:,:), recv_all_pos_start(:,:,:),&
+                            send_i2b_s0(:), send_i2b_i0a(:), &
+                            send_i2b_s1(:), send_i2b_i1a(:), &
+                            send_i2b_s2(:), send_i2b_i2a(:), &
+                            recv_i2b_s0(:), recv_i2b_i0a(:), &
+                            recv_i2b_s1(:), recv_i2b_i1a(:), &
+                            recv_i2b_s2(:), recv_i2b_i2a(:), &
+                            all_request(:), all_status(:,:), all_rank_comm_kk(:)
+    logical              :: initialized = .false.
+    logical              :: use_alltoallv, use_isendirecv, use_nccl, chosen_backend, single_device, &
+                            apply_autotune_reorder
+    real(rp)             :: elapsed_time_reorder(0:5), elapsed_alltoallv,elapsed_isendirecv,elapsed_nccl,&
+                            recv_elapsed_simul_top, recv_elapsed_batched_top, recv_elapsed_simul_modes(0:5) , &
+                            send_elapsed_simul_top, send_elapsed_batched_top, send_elapsed_simul_modes(0:5) , &
+                            recv_elapsed_batched_modes(0:5) , &
+                            send_elapsed_batched_modes(0:5)
+  end type
+
+  contains
+
+  ! ---------------------------------------- diezdecomp halo ------------------------------------------------
+  subroutine diezdecomp_fill_halo_props(this, ii, is_per, ranks_ii, flat_ranks_ii, shape_ranks_ii, nh_xyz, abs_order, &
+                                 loc_shape_full, offset6, irank, nproc, halo_mpi_mode, autotuned_pack)
+    implicit none
+    type(diezdecomp_props_halo) :: this
+    integer                    :: ii, nh_xyz(0:2), abs_order(0:2), irank, jj, kk, rel_pos, L, p0, p1, &
+                                  k, size_dir, loc_shape(0:2), loc_shape_full(0:2), loc_shape_padded(0:2), nproc, &
+                                  ranks_ii(0:,0:,0:), flat_ranks_ii(0:,0:), shape_ranks_ii(0:2), halo_mpi_mode, &
+                                  autotuned_pack, offset6(0:2,0:1)
+    logical                    :: is_per
+    ! call check_bounds(ii, 0, 2)
+    loc_shape_padded = [loc_shape_full(0) - offset6(0,0) - offset6(0,1),&
+                        loc_shape_full(1) - offset6(1,0) - offset6(1,1),&
+                        loc_shape_full(2) - offset6(2,0) - offset6(2,1)]
+    this%irank = irank
+    this%nproc = nproc
+
+    this%elapsed_sendrecv   = -1
+    this%elapsed_isendirecv = -1
+    this%wtime_2            = -1
+    this%wtime_3            = -1
+
+    do k=0,2
+      this%nh_ijk(k) = nh_xyz(abs_order(k))
+      loc_shape(k)   = loc_shape_padded(k) - 2*this%nh_ijk(k)
+    end do
+
+    this%loc_shape(:) = loc_shape(:)
+
+    if      (ii == 0) then ; jj = 1; kk = 2
+    else if (ii == 1) then ; jj = 0; kk = 2
+    else if (ii == 2) then ; jj = 0; kk = 1
+    else                   ; error stop 'ERROR: unrecognized ii' ! , ii
+    end if
+
+    this%nh_dir             = nh_xyz(ii)
+    this%side_numel         = loc_shape_padded(diezdecomp_get_index_int2int(abs_order,jj))* &
+                              loc_shape_padded(diezdecomp_get_index_int2int(abs_order,kk))* this%nh_dir
+    rel_pos                 = get_position_in_3darr(flat_ranks_ii, irank, ii)
+    this%dir_pick           = diezdecomp_get_index_int2int(abs_order,ii)
+
+    size_dir                = shape_ranks_ii(ii)
+    this%args_rel_pos_align = rel_pos
+    if (mod(rel_pos,2) == 0) then
+      p0 = 0  ;  p1 = 1
+    else
+      p0 = 1  ;  p1 = 0 ! this is necessary for force_sync_halo, and good for isend/irecv
+    end if
+
+    this%args_active      (p0) = is_per.or.(rel_pos>0)
+    this%args_other_id    (p0) = diezdecomp_get_rank_id(ranks_ii, flat_ranks_ii, shape_ranks_ii, irank, ii, -1)
+    this%args_inds_recv_i0(p0) = 0
+    this%args_inds_recv_i1(p0) = this%nh_dir - 1
+    this%args_inds_send_i0(p0) = this%nh_dir
+    this%args_inds_send_i1(p0) = 2*this%nh_dir - 1
+    this%args_tag_send    (p0) = 2
+    this%args_tag_recv    (p0) = 1
+    this%args_pos_send    (p0) = 0
+    this%args_pos_recv    (p0) = 2*this%side_numel
+    L                          = this%loc_shape(this%dir_pick)
+
+    this%args_active      (p1) = is_per.or.(rel_pos<(size_dir-1))
+    this%args_other_id    (p1) = diezdecomp_get_rank_id(ranks_ii, flat_ranks_ii, shape_ranks_ii, irank, ii,  1)
+    this%args_inds_recv_i0(p1) = L + this%args_inds_send_i0(p0)
+    this%args_inds_recv_i1(p1) = L + this%args_inds_send_i1(p0)
+    this%args_inds_send_i0(p1) = L + this%args_inds_recv_i0(p0)
+    this%args_inds_send_i1(p1) = L + this%args_inds_recv_i1(p0)
+    this%args_tag_send    (p1) = 1
+    this%args_tag_recv    (p1) = 2
+    this%args_pos_send    (p1) =   this%side_numel
+    this%args_pos_recv    (p1) = 3*this%side_numel
+
+    this%halo_mpi_mode  = halo_mpi_mode
+    this%autotuned_pack = autotuned_pack
+    this%offset3(0:2)   = offset6(0:2,0)
+    this%initialized    = .true.
+  end subroutine
+
+  subroutine diezdecomp_halos_execute(this, p, buffer, stream)
+    implicit none
+    type(diezdecomp_props_halo) :: this
+    real(rp) :: p(0:,0:,0:), buffer(0:*)
+    real(dp) :: wtime_2, wtime_3, temp_real
+    integer  :: i,mpi_ierr
+    integer(acc_handle_kind) :: stream
+    if (this%nh_dir>0) then
+      wtime_2 = 0
+      wtime_3 = 0
+      do i = 0,1
+        if (this%args_active(i)) then
+          call pack_slices_halo(p, buffer, this%args_pos_send(i), this%args_inds_send_i0(i), &
+                                                                  this%args_inds_send_i1(i), &
+                                                                  this%dir_pick, this%loc_shape, this%nh_ijk, .true., &
+                                                                  this%offset3, this%autotuned_pack,wtime_2,wtime_3, stream)
+        end if
+      end do
+      call comm_halo_mpi(this, buffer, stream)
+      do i = 0,1
+        if (this%args_active(i)) then
+          call pack_slices_halo(p, buffer, this%args_pos_recv(i), this%args_inds_recv_i0(i), &
+                                                                  this%args_inds_recv_i1(i), &
+                                                                  this%dir_pick, this%loc_shape, this%nh_ijk, .false.,&
+                                                                  this%offset3, this%autotuned_pack,wtime_2,wtime_3, stream)
+
+        end if
+      end do
+      if ((this%autotuned_pack < 2).or.(3 < this%autotuned_pack)) then
+        temp_real = wtime_2/(this%nproc*1._dp)
+        call MPI_Allreduce(temp_real, wtime_2, 1, MPI_DOUBLE_PRECISION, mpi_sum, mpi_comm_world, mpi_ierr)
+        temp_real = wtime_3/(this%nproc*1._dp)
+        call MPI_Allreduce(temp_real, wtime_3, 1, MPI_DOUBLE_PRECISION, mpi_sum, mpi_comm_world, mpi_ierr)
+        this%autotuned_pack = 3
+        if (wtime_2<wtime_3) this%autotuned_pack = 2
+        this%wtime_2  =  wtime_2
+        this%wtime_3  =  wtime_3
+      end if
+    end if
+  end subroutine
+
+  recursive subroutine comm_halo_mpi(this, buffer, stream)
+    implicit none
+    type(diezdecomp_props_halo) :: this
+    real(rp) :: buffer(0:*)
+    integer :: i, mpi_ierr, ireq, mode_best, mode_try,pos
+    integer(acc_handle_kind) :: stream
+    real(dp) :: elapsed_time,elapsed_best,temp_wtime, temp_real
+
+    if ((this%halo_mpi_mode<1).or.(2<this%halo_mpi_mode)) then
+      elapsed_best = LARGE
+      do mode_try=1,2
+        this%halo_mpi_mode = mode_try
+        do pos=1,diezdecomp_n_warmup ; call comm_halo_mpi(this, buffer, stream) ; end do
+        if (diezdecomp_mode_bench_avg) then ; elapsed_time = 0.
+        else                                ; elapsed_time = LARGE ; end if
+        do pos=1,diezdecomp_autotune_mode_trials
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime()
+          call comm_halo_mpi(this, buffer, stream)
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime() - temp_wtime
+          if (diezdecomp_mode_bench_avg) then
+            elapsed_time = elapsed_time + temp_wtime/(diezdecomp_autotune_mode_trials*1._dp)
+          else
+            elapsed_time = min(elapsed_time, temp_wtime)
+          end if
+        end do
+        temp_real = elapsed_time/(this%nproc*1._dp)
+        call MPI_Allreduce(temp_real, elapsed_time, 1, MPI_DOUBLE_PRECISION, mpi_sum, mpi_comm_world, mpi_ierr)
+        if (mode_try==1) this%elapsed_sendrecv   = elapsed_time
+        if (mode_try==2) this%elapsed_isendirecv = elapsed_time
+        if (elapsed_time<elapsed_best) then
+          elapsed_best = elapsed_time
+          mode_best    = mode_try
+        end if
+      end do
+      this%halo_mpi_mode = mode_best
+    else
+    ireq = 0
+    !$acc wait(stream)
+    do i = 0,1
+      if (this%args_active(i)) then
+        if (this%irank /= this%args_other_id(i)) then
+          if (this%halo_mpi_mode==1) then
+            !$acc host_data use_device(buffer)
+call MPI_Sendrecv(buffer(this%args_pos_send(i)), this%side_numel, MPI_REAL_RP, this%args_other_id(i), this%args_tag_send(i),&
+            buffer(this%args_pos_recv(i)), this%side_numel, MPI_REAL_RP, this%args_other_id(i), this%args_tag_recv(i),&
+            mpi_comm_world, this%all_status(:,0), mpi_ierr)
+            !$acc end host_data
+          else if (this%halo_mpi_mode==2) then
+call isendrecv_1d_buffer(.false., buffer, this%args_pos_recv(i), this%side_numel, &
+                         this%args_other_id(i),this%args_tag_recv(i), mpi_comm_world, this%all_request(ireq  ))
+call isendrecv_1d_buffer(.true., buffer, this%args_pos_send(i), this%side_numel, &
+                         this%args_other_id(i),this%args_tag_send(i), mpi_comm_world, this%all_request(ireq+1))
+            ireq = ireq + 2
+          else
+            error stop 'ERROR: this%halo_mpi_mode out-of-range'
+          end if
+        end if
+      end if
+    end do
+      do i = 0,1
+      if (this%args_active(i)) then
+        if (this%irank == this%args_other_id(i)) then
+if (this%irank /= this%args_other_id(1-i)) error stop 'ERROR: halos ids:' ! , this%irank,this%args_other_id
+          call copy_1d_buffer(buffer, buffer, this%args_pos_send(i), this%args_pos_recv(1-i), this%side_numel, stream)
+        end if
+      end if
+    end do
+    if (ireq>0) call mpi_waitall(ireq, this%all_request, this%all_status, mpi_ierr)
+    !$acc wait(stream)
+    end if
+  end subroutine
+
+  subroutine pack_slices_halo(p, buffer, pos_ini, inds_pick_i0, inds_pick_i1, dir_pick, loc_shape, nh_ijk, mode_fwd, &
+                              offset3, autotuned, wtime_2, wtime_3, stream)
+    real(rp) :: p(0:,0:,0:), buffer(0:*)
+    integer  :: loc_shape(0:), &
+                pos_ini, inds_pick_i0, inds_pick_i1, dir_pick, nh_ijk(0:2), &
+                autotuned,iter1, mode_iter, &
+                offset3(0:2)
+    logical  :: mode_fwd
+    integer(acc_handle_kind) :: stream
+    real(dp) :: elapsed_time, temp_wtime, wtime_2, wtime_3
+    if ((autotuned < 2).or.(3 < autotuned)) then
+      do mode_iter=2,3
+        if (diezdecomp_mode_bench_avg) then ; elapsed_time = 0.
+        else                                ; elapsed_time = LARGE ; end if
+        do iter1 = 1,diezdecomp_autotune_mode_trials
+          if      (mode_iter==2) then
+            !$acc wait(stream)
+            temp_wtime = MPI_Wtime()
+            call pack_slices_2d(p, buffer, pos_ini, inds_pick_i0, inds_pick_i1, dir_pick, loc_shape, nh_ijk, mode_fwd, &
+                                offset3, stream)
+            !$acc wait(stream)
+            temp_wtime = MPI_Wtime() - temp_wtime
+          else if (mode_iter==3) then
+            !$acc wait(stream)
+            temp_wtime = MPI_Wtime()
+            call pack_slices_3d(p, buffer, pos_ini, inds_pick_i0, inds_pick_i1, dir_pick, loc_shape, nh_ijk, mode_fwd, &
+                                offset3, stream)
+            !$acc wait(stream)
+            temp_wtime = MPI_Wtime() - temp_wtime
+          else
+            error stop 'ERROR: Unrecognized mode_iter'
+          end if
+          if (diezdecomp_mode_bench_avg) then
+            elapsed_time = elapsed_time + temp_wtime/(diezdecomp_autotune_mode_trials*1._dp)
+          else
+            elapsed_time = min(elapsed_time, temp_wtime)
+          end if
+        end do
+        if (mode_iter==2) wtime_2 = wtime_2 + elapsed_time
+        if (mode_iter==3) wtime_3 = wtime_3 + elapsed_time
+      end do
+    else
+      !$acc wait(stream)
+      if      (autotuned == 2) then
+        call pack_slices_2d(p, buffer, pos_ini, inds_pick_i0, inds_pick_i1, dir_pick, loc_shape, nh_ijk, mode_fwd, &
+                            offset3, stream)
+      else if (autotuned == 3) then
+        call pack_slices_3d(p, buffer, pos_ini, inds_pick_i0, inds_pick_i1, dir_pick, loc_shape, nh_ijk, mode_fwd, &
+                            offset3, stream)
+      else
+        error stop 'ERROR: autotuned out-of-range (pack_slices_halo)'
+      endif
+      !$acc wait(stream)
+    end if
+  end subroutine
+
+  subroutine pack_slices_2d(p, buffer, pos_ini, inds_pick_i0, inds_pick_i1, dir_pick, loc_shape, nh_ijk, mode_fwd, &
+                            offset3, stream)
+    implicit none
+    real(rp) :: p(0:,0:,0:), buffer(0:*)
+    integer  :: loc_shape(0:), &
+                pos_ini, inds_pick_i0, inds_pick_i1, dir_pick, ni, nj, nk, nh_ijk(0:2), &
+                i,j,k,pos,pos_start, offset3(0:2), di,dj,dk
+    logical  :: mode_fwd
+    integer(acc_handle_kind) :: stream
+    ! call check_bounds(dir_pick,0, 2)
+    di = offset3(0) ; dj = offset3(1) ; dk = offset3(2)
+    ni = loc_shape(0)+ 2*nh_ijk(0)
+    nj = loc_shape(1)+ 2*nh_ijk(1)
+    nk = loc_shape(2)+ 2*nh_ijk(2)
+    pos = pos_ini + 0
+    if (dir_pick == 0) then
+      do i=inds_pick_i0,inds_pick_i1
+        pos_start = pos + 0
+        if (mode_fwd) then
+          !$acc parallel loop gang vector collapse(2) default(present) async(stream)
+          do k = 0, nk-1
+          do j = 0, nj-1
+            buffer(pos_start + k*nj + j) = p(i+di,j+dj,k+dk)
+          end do
+          end do
+        else
+          !$acc parallel loop gang vector collapse(2) default(present) async(stream)
+          do k = 0, nk-1
+          do j = 0, nj-1
+            p(i+di,j+dj,k+dk) = buffer(pos_start + k*nj + j)
+          end do
+          end do
+        end if
+        pos = pos + nk*nj
+      end do
+    else if (dir_pick == 1) then
+      do j=inds_pick_i0,inds_pick_i1
+        pos_start = pos + 0
+        if (mode_fwd) then
+          !$acc parallel loop gang vector collapse(2) default(present) async(stream)
+          do k = 0, nk-1
+          do i = 0, ni-1
+            buffer(pos_start + k*ni + i) = p(i+di,j+dj,k+dk)
+          end do
+          end do
+        else
+          !$acc parallel loop gang vector collapse(2) default(present) async(stream)
+          do k = 0, nk-1
+          do i = 0, ni-1
+            p(i+di,j+dj,k+dk) = buffer(pos_start + k*ni + i)
+          end do
+          end do
+        end if
+        pos = pos + nk*ni
+      end do
+    else if (dir_pick == 2) then
+      do k=inds_pick_i0,inds_pick_i1
+        pos_start = pos + 0
+        if (mode_fwd) then
+          !$acc parallel loop gang vector collapse(2) default(present) async(stream)
+          do j = 0, nj-1
+          do i = 0, ni-1
+            buffer(pos_start + j*ni + i) = p(i+di,j+dj,k+dk)
+          end do
+          end do
+        else
+          !$acc parallel loop gang vector collapse(2) default(present) async(stream)
+          do j = 0, nj-1
+          do i = 0, ni-1
+            p(i+di,j+dj,k+dk) = buffer(pos_start + j*ni + i)
+          end do
+          end do
+        end if
+        pos = pos + nj*ni
+      end do
+    else
+      error stop 'ERROR: dir_pick not detected: ' ! , dir_pick
+    end if
+  end subroutine
+
+  subroutine pack_slices_3d(p, buffer, pos_ini, inds_pick_i0, inds_pick_i1, dir_pick, loc_shape, nh_ijk, mode_fwd, &
+                            offset3, stream)
+    implicit none
+    real(rp) :: p(0:,0:,0:), buffer(0:*)
+    integer  :: loc_shape(0:), &
+                pos_ini, inds_pick_i0, inds_pick_i1, dir_pick, ni, nj, nk, nh_ijk(0:2), &
+                i,j,k,pos_start,i0,i1,j0,j1,k0,k1,nji,di,dj,dk, offset3(0:2)
+    logical  :: mode_fwd
+    integer(acc_handle_kind) :: stream
+    ! call check_between(dir_pick,0, 2)
+    ni = loc_shape(0)+ 2*nh_ijk(0)
+    nj = loc_shape(1)+ 2*nh_ijk(1)
+    nk = loc_shape(2)+ 2*nh_ijk(2)
+    i0 = 0 ; i1 = ni-1
+    j0 = 0 ; j1 = nj-1
+    k0 = 0 ; k1 = nk-1
+    di = offset3(0) ; dj = offset3(1) ; dk = offset3(2)
+    if      (dir_pick ==0) then  ; i0 = inds_pick_i0 ; i1 = inds_pick_i1
+    else if (dir_pick ==1) then  ; j0 = inds_pick_i0 ; j1 = inds_pick_i1
+    else if (dir_pick ==2) then  ; k0 = inds_pick_i0 ; k1 = inds_pick_i1
+    else                         ; error stop 'ERROR: dir_pick not detected: ' ! , dir_pick
+    end if
+    ni  = i1 - i0 + 1
+    nj  = j1 - j0 + 1
+    nk  = k1 - k0 + 1
+    nji = nj*ni
+    if      (dir_pick ==0) then ; pos_start = pos_ini - i0
+    else if (dir_pick ==1) then ; pos_start = pos_ini - j0*ni
+    else if (dir_pick ==2) then ; pos_start = pos_ini - k0*nji
+    end if
+    if (mode_fwd) then
+      !$acc parallel loop gang vector collapse(3) default(present) async(stream)
+      do k = k0,k1
+      do j = j0,j1
+      do i = i0,i1
+        buffer(pos_start + k*nji + j*ni + i) = p(i+di,j+dj,k+dk)
+      end do
+      end do
+      end do
+    else
+      !$acc parallel loop gang vector collapse(3) default(present) async(stream)
+      do k = k0,k1
+      do j = j0,j1
+      do i = i0,i1
+        p(i+di,j+dj,k+dk) = buffer(pos_start + k*nji + j*ni + i)
+      end do
+      end do
+      end do
+    end if
+  end subroutine
+
+  ! ---------------------------------------- diezdecomp transpose -------------------------------------------
+  subroutine diezdecomp_fill_transp_props(this, abs_reorder, loc_order_a, loc_order_b, lo_a, hi_a, lo_b, hi_b, &
+                                  ii_jj_kk, irank, nproc, allow_alltoallv, sp_in_full, offset6_in, &
+                                  sp_out_full, offset6_out, allow_autotune_reorder, stream)
+    implicit none
+    type(diezdecomp_props_transp) :: this
+    integer                  :: ks, kr, kreq, pos, mpi_ierr, &
+                                nproc, irank, prev_pos, jj_pos, kk_pos, &
+                                abs_reorder(0:2), loc_order_a(0:2), loc_order_b(0:2), &
+                                lo_a(0:2),     hi_a(0:2),     lo_b(0:2),     hi_b(0:2), &
+                                sp_in_0, sp_in_1, sp_in_2, sp_out_0, sp_out_1, sp_out_2, ii_jj_kk(0:2), &
+                                offset6_in(0:2,0:1), offset6_out(0:2,0:1), sp_in_full(0:2), sp_out_full(0:2)
+    integer, allocatable     :: all_lo_a(:,:), all_hi_a(:,:), all_lo_b(:,:), all_hi_b(:,:), &
+                                temp_buffer(:,:), temp_buffer_sort(:,:), aux1(:,:), aux2(:,:)
+    logical                  :: allow_alltoallv, allow_autotune_reorder
+    integer(acc_handle_kind) :: stream
+    this%irank = irank
+    this%nproc = nproc
+    this%order_a(0:2) = loc_order_a(0:2)
+    this%order_b(0:2) = loc_order_b(0:2)
+
+    sp_in_0  = sp_in_full(0)  - offset6_in(0,0)  - offset6_in(0,1)
+    sp_in_1  = sp_in_full(1)  - offset6_in(1,0)  - offset6_in(1,1)
+    sp_in_2  = sp_in_full(2)  - offset6_in(2,0)  - offset6_in(2,1)
+    sp_out_0 = sp_out_full(0) - offset6_out(0,0) - offset6_out(0,1)
+    sp_out_1 = sp_out_full(1) - offset6_out(1,0) - offset6_out(1,1)
+    sp_out_2 = sp_out_full(2) - offset6_out(2,0) - offset6_out(2,1)
+
+    this%offset6_in  = offset6_in
+    this%offset6_out = offset6_out
+
+    this%sp_in_0 = sp_in_0
+    this%sp_in_1 = sp_in_1
+    this%sp_in_2 = sp_in_2
+
+    this%sp_out_0 = sp_out_0
+    this%sp_out_1 = sp_out_1
+    this%sp_out_2 = sp_out_2
+
+    this%numel_p_in  = sp_in_0  * sp_in_1  * sp_in_2
+    this%numel_p_out = sp_out_0 * sp_out_1 * sp_out_2
+
+    block
+      integer :: i,j,k,pos
+      this%elapsed_time_reorder               = -1
+      this%elapsed_alltoallv                  = -1
+      this%elapsed_isendirecv                 = -1
+      this%elapsed_nccl                       = -1
+      this%reorder_ijk                        = -1
+      this%chosen_reorder                     = -1
+      this%send_elapsed_simul_top             = -1
+      this%send_elapsed_batched_top           = -1
+      this%send_elapsed_simul_modes           = -1
+      this%send_elapsed_batched_modes         = -1
+      this%recv_elapsed_simul_top             = -1
+      this%recv_elapsed_batched_top           = -1
+      this%recv_elapsed_simul_modes           = -1
+      this%recv_elapsed_batched_modes         = -1
+      pos = -1
+      do i=0,2
+        do j=0,2
+          if (i /= j) then
+            pos = pos + 1
+            k   = 3-i-j
+            this%reorder_ijk(0:2,pos) = [i,j,k]
+          end if
+        end do
+      end do
+      if (pos /= 5) error stop 'ERROR: autotune reorder: pos /= 5'
+    end block
+
+    ! i) intersect ijk coordinates to find subdomains
+    allocate(all_lo_a        (0:2, 0:nproc-1), &
+             all_hi_a        (0:2, 0:nproc-1), &
+             all_lo_b        (0:2, 0:nproc-1), &
+             all_hi_b        (0:2, 0:nproc-1), &
+             temp_buffer     (0:nproc-1,0:7) , &
+             temp_buffer_sort(0:nproc-1,0:7) )
+
+    call MPI_Allgather(lo_a, 3, mpi_int, all_lo_a, 3, mpi_int, mpi_comm_world, mpi_ierr)
+    call MPI_Allgather(hi_a, 3, mpi_int, all_hi_a, 3, mpi_int, mpi_comm_world, mpi_ierr)
+    call MPI_Allgather(lo_b, 3, mpi_int, all_lo_b, 3, mpi_int, mpi_comm_world, mpi_ierr)
+    call MPI_Allgather(hi_b, 3, mpi_int, all_hi_b, 3, mpi_int, mpi_comm_world, mpi_ierr)
+
+    ! send information
+    call transp_match_intervals(lo_a, hi_a, all_lo_b, all_hi_b, &
+                             temp_buffer, temp_buffer_sort, ks, nproc, loc_order_a, loc_order_b)
+    allocate(this%send_i0_st    (0:ks    ), &
+             this%send_i1_st    (0:ks    ), &
+             this%send_i2_st    (0:ks    ), &
+             this%send_b_i0     (0:ks    ), &
+             this%send_b_i1     (0:ks    ), &
+             this%send_b_i2     (0:ks    ), &
+             this%send_ids      (0:ks    ), &
+             this%send_lshape   (0:ks,0:2), &
+             this%send_sizes    (0:ks    ), &
+             this%send_pos_start(0:ks    ), &
+             this%send_tags     (0:ks    ))
+    this%send_i0_st (0:ks    ) = temp_buffer(0:ks,  0) - lo_a(0)
+    this%send_i1_st (0:ks    ) = temp_buffer(0:ks,  1) - lo_a(1)
+    this%send_i2_st (0:ks    ) = temp_buffer(0:ks,  2) - lo_a(2)
+    this%send_ids   (0:ks    ) = temp_buffer(0:ks,  3)
+    this%send_lshape(0:ks,0:2) = temp_buffer(0:ks,4:6)
+
+    ! recv information
+    call transp_match_intervals(lo_b, hi_b, all_lo_a, all_hi_a, &
+                                temp_buffer, temp_buffer_sort, kr, nproc, loc_order_b, loc_order_a)
+    allocate(this%recv_i0_st    (0:kr    ), &
+             this%recv_i1_st    (0:kr    ), &
+             this%recv_i2_st    (0:kr    ), &
+             this%recv_b_i0     (0:kr    ), &
+             this%recv_b_i1     (0:kr    ), &
+             this%recv_b_i2     (0:kr    ), &
+             this%recv_ids      (0:kr    ), &
+             this%recv_lshape   (0:kr,0:2), &
+             this%recv_sizes    (0:kr    ), &
+             this%recv_pos_start(0:kr    ), &
+             this%recv_tags     (0:kr    ))
+    this%recv_i0_st (0:kr    ) = temp_buffer(0:kr,  0) - lo_b(0)
+    this%recv_i1_st (0:kr    ) = temp_buffer(0:kr,  1) - lo_b(1)
+    this%recv_i2_st (0:kr    ) = temp_buffer(0:kr,  2) - lo_b(2)
+    this%recv_ids   (0:kr    ) = temp_buffer(0:kr,  3)
+    this%recv_lshape(0:kr,0:2) = temp_buffer(0:kr,4:6)
+
+    ! ii) complete recv/send variables
+    kreq = ks + kr + 1
+    allocate(this%all_request(0:kreq), this%all_status(MPI_STATUS_SIZE, 0:kreq), this%all_rank_comm_kk(0:nproc-1))
+
+    this%best_send_mode_op_batched = -1
+    this%best_recv_mode_op_batched = -1
+    this%best_send_mode_op_simul   = -1
+    this%best_recv_mode_op_simul   = -1
+    this%best_send_autotuned       = -1
+    this%best_recv_autotuned       = -1
+
+    prev_pos = 0
+    do pos=0,ks
+      this%send_sizes(pos)     = product(this%send_lshape(pos,0:2))
+      this%send_tags(pos)      = 1 + this%irank * nproc + this%send_ids(pos) ! 1 + sender * nproc + recv
+      this%send_pos_start(pos) = prev_pos
+      prev_pos                 = prev_pos + this%send_sizes(pos)
+    end do
+    prev_pos = 0
+    do pos=0,kr
+      this%recv_sizes(pos)     = product(this%recv_lshape(pos,0:2))
+      this%recv_tags(pos)      = 1 + this%recv_ids(pos) * nproc + this%irank ! 1 + sender * nproc + recv
+      this%recv_pos_start(pos) = prev_pos
+      prev_pos                 = prev_pos + this%recv_sizes(pos)
+    end do
+
+    ! iii) single_device calls (if applicable)
+    this%single_device = ((size(this%send_ids,1) == 1).and.&
+                          (size(this%recv_ids,1) == 1).and.&
+                          (this%send_ids(0) == this%irank).and.&
+                          (this%recv_ids(0) == this%irank))
+
+    !this%recv_tags(:) = 0
+    !this%send_tags(:) = 0
+
+    this%use_isendirecv = .true. ! always possible
+    this%chosen_backend = .false.
+!#if defined(_DIEZDECOMP_NCCL)
+!    this%use_nccl       = .true.
+!    if (.not.nccl_is_init) then
+!      nccl_is_init = .true.
+!      if (this%irank == 0) nccl_stat = ncclGetUniqueId(nccl_id)
+!      call MPI_Bcast(nccl_id%internal, int(sizeof(nccl_id%internal)), MPI_BYTE, 0, mpi_comm_world, mpi_ierr)
+!      nccl_stat = ncclCommInitRank(nccl_comm, nproc, nccl_id, this%irank)
+!      mpi_ierr = cudaStreamCreateWithFlags(nccl_stream, cudaStreamNonBlocking)
+!    end if
+!#else
+    this%use_nccl       = .false.
+!#endif
+
+    ! iv) setup alltoallv communication (if applicable)
+    this%use_alltoallv = allow_alltoallv.and.(.not.this%single_device)
+    if (ks /= kr) then
+      this%use_alltoallv = .false.
+    else
+      do pos=0,ks
+        if (this%send_ids(pos) /= this%recv_ids(pos)) this%use_alltoallv = .false.
+      end do
+    endif
+    block
+      integer :: vmin,vmax
+      call MPI_Allreduce(ks, vmax, 1, mpi_int, mpi_max, mpi_comm_world, mpi_ierr)
+      call MPI_Allreduce(ks, vmin, 1, mpi_int, mpi_min, mpi_comm_world, mpi_ierr)
+      if (vmin /= vmax) this%use_alltoallv = .false.
+    end block
+    if (this%use_alltoallv) then
+      block
+        integer :: k0,k1,s(0:2), temp_int, ii,jj,kk
+        ii = ii_jj_kk(0)
+        jj = ii_jj_kk(1)
+        kk = ii_jj_kk(2)
+        k0 = -1
+        k1 = -1
+        s  = [sp_in_0, sp_in_1, sp_in_2]
+        call check_a2av_alignment(this%send_ids, ks, ii, jj, kk, k0, k1, s, this%order_a, all_lo_a, all_hi_a, &
+                                  this%use_alltoallv, this%irank, jj_pos)
+        s  = [sp_out_0, sp_out_1, sp_out_2]
+        call check_a2av_alignment(this%recv_ids, kr, jj, ii, kk, k0, k1, s, this%order_b, all_lo_b, all_hi_b, &
+                                  this%use_alltoallv, this%irank, temp_int)
+        kk_pos = k0
+      end block
+    end if
+    ! deallocate buffers
+    deallocate(all_lo_a        , &
+               all_hi_a        , &
+               all_lo_b        , &
+               all_hi_b        , &
+               temp_buffer     , &
+               temp_buffer_sort)
+    block
+      logical :: temp_bool
+      temp_bool = this%use_alltoallv
+      call MPI_Allreduce(temp_bool, this%use_alltoallv, 1, mpi_logical, mpi_land, mpi_comm_world, mpi_ierr)
+    end block
+
+    if (this%use_alltoallv) then
+      call MPI_Comm_split(mpi_comm_world, kk_pos+1, jj_pos+1 , this%mpi_comm_kk, mpi_ierr)
+      write(*,*) 'INFO: using alltoallv', this%irank
+      ! note: mpi implementations rarely simplify unnecessary (local -> local) calls
+    else
+      this%mpi_comm_kk = mpi_comm_world
+    !  write(*,*) 'INFO: using isend/irecv', this%irank
+    end if
+
+    call MPI_Comm_Rank(this%mpi_comm_kk, this%irank_comm_kk, mpi_ierr)
+    call MPI_Allgather(this%irank_comm_kk   , 1, mpi_int,&
+                       this%all_rank_comm_kk, 1, mpi_int, mpi_comm_world, mpi_ierr)
+    ! v) configure local -> local transfers (if applicable)
+    this%pos_start_localSend = -1
+    this%pos_start_localRecv = -1
+    do pos=0,ks
+      if (this%send_ids(pos) == this%irank) then
+        if (this%pos_start_localSend>=0) error stop 'ERROR: this%pos_start_localSend >= 0:' ! , this%pos_start_localSend
+        this%pos_start_localSend = this%send_pos_start(pos)
+        this%size_localSend      = this%send_sizes(pos)
+      end if
+    end do
+    do pos=0,kr
+      if (this%recv_ids(pos) == this%irank) then
+        if (this%pos_start_localRecv>=0) error stop 'ERROR: this%pos_start_localRecv >= 0:' ! , this%pos_start_localRecv
+        this%pos_start_localRecv = this%recv_pos_start(pos)
+        this%size_localRecv      = this%recv_sizes(pos)
+      end if
+    end do
+
+    ! vi) block variables
+    allocate(this%send_i2b_s0(minval(this%send_i0_st):maxval(this%send_i0_st+this%send_lshape(:,0)-1)),&
+             this%send_i2b_s1(minval(this%send_i1_st):maxval(this%send_i1_st+this%send_lshape(:,1)-1)),&
+             this%send_i2b_s2(minval(this%send_i2_st):maxval(this%send_i2_st+this%send_lshape(:,2)-1)),&
+             this%recv_i2b_s0(minval(this%recv_i0_st):maxval(this%recv_i0_st+this%recv_lshape(:,0)-1)),&
+             this%recv_i2b_s1(minval(this%recv_i1_st):maxval(this%recv_i1_st+this%recv_lshape(:,1)-1)),&
+             this%recv_i2b_s2(minval(this%recv_i2_st):maxval(this%recv_i2_st+this%recv_lshape(:,2)-1)),&
+
+             this%send_i2b_i0a(minval(this%send_i0_st):maxval(this%send_i0_st+this%send_lshape(:,0)-1)),&
+             this%send_i2b_i1a(minval(this%send_i1_st):maxval(this%send_i1_st+this%send_lshape(:,1)-1)),&
+             this%send_i2b_i2a(minval(this%send_i2_st):maxval(this%send_i2_st+this%send_lshape(:,2)-1)),&
+             this%recv_i2b_i0a(minval(this%recv_i0_st):maxval(this%recv_i0_st+this%recv_lshape(:,0)-1)),&
+             this%recv_i2b_i1a(minval(this%recv_i1_st):maxval(this%recv_i1_st+this%recv_lshape(:,1)-1)),&
+             this%recv_i2b_i2a(minval(this%recv_i2_st):maxval(this%recv_i2_st+this%recv_lshape(:,2)-1)),&
+
+             aux1(max(ks,kr)+1,2),&
+             aux2(max(ks,kr)+1,2))
+
+    call mk_blocks_1d(this%send_i0_st, this%send_lshape(:,0), this%send_b_i0, this%send_i2b_s0, this%send_i2b_i0a, aux1, aux2)
+    call mk_blocks_1d(this%send_i1_st, this%send_lshape(:,1), this%send_b_i1, this%send_i2b_s1, this%send_i2b_i1a, aux1, aux2)
+    call mk_blocks_1d(this%send_i2_st, this%send_lshape(:,2), this%send_b_i2, this%send_i2b_s2, this%send_i2b_i2a, aux1, aux2)
+    call mk_blocks_1d(this%recv_i0_st, this%recv_lshape(:,0), this%recv_b_i0, this%recv_i2b_s0, this%recv_i2b_i0a, aux1, aux2)
+    call mk_blocks_1d(this%recv_i1_st, this%recv_lshape(:,1), this%recv_b_i1, this%recv_i2b_s1, this%recv_i2b_i1a, aux1, aux2)
+    call mk_blocks_1d(this%recv_i2_st, this%recv_lshape(:,2), this%recv_b_i2, this%recv_i2b_s2, this%recv_i2b_i2a, aux1, aux2)
+
+    deallocate(aux1,aux2)
+
+    !$acc enter data copyin(this)
+    !$acc enter data copyin(this%send_i2b_s0 , this%send_i2b_s1 , this%send_i2b_s2 ) async(stream)
+    !$acc enter data copyin(this%send_i2b_i0a, this%send_i2b_i1a, this%send_i2b_i2a) async(stream)
+    !$acc enter data copyin(this%recv_i2b_s0 , this%recv_i2b_s1 , this%recv_i2b_s2 ) async(stream)
+    !$acc enter data copyin(this%recv_i2b_i0a, this%recv_i2b_i1a, this%recv_i2b_i2a) async(stream)
+    !$acc wait(stream)
+
+    allocate(this%send_all_n0(minval(this%send_b_i0):maxval(this%send_b_i0),&
+                              minval(this%send_b_i1):maxval(this%send_b_i1),&
+                              minval(this%send_b_i2):maxval(this%send_b_i2)))
+    allocate(this%recv_all_n0(minval(this%recv_b_i0):maxval(this%recv_b_i0),&
+                              minval(this%recv_b_i1):maxval(this%recv_b_i1),&
+                              minval(this%recv_b_i2):maxval(this%recv_b_i2)))
+    allocate(this%send_all_n1       , mold=this%send_all_n0)
+    allocate(this%send_all_n2       , mold=this%send_all_n0)
+    allocate(this%send_all_pos_start, mold=this%send_all_n0)
+    allocate(this%recv_all_n1       , mold=this%recv_all_n0)
+    allocate(this%recv_all_n2       , mold=this%recv_all_n0)
+    allocate(this%recv_all_pos_start, mold=this%recv_all_n0)
+
+    block
+      integer :: abs0_reorder(0:2)
+      if (((minval(abs0_reorder)==0).and.(maxval(abs0_reorder) == 2).and.(sum(abs0_reorder) == 3)).and.&
+           (.not.this%single_device)) then
+        abs0_reorder = abs_reorder
+      else
+        abs0_reorder = this%order_b(0:2)
+      end if
+      !$acc wait(stream)
+      call diezdecomp_update_order_intermediate(this, abs0_reorder)
+    end block
+
+    block
+      logical :: temp_bool
+      temp_bool = (allow_autotune_reorder.and.(.not.this%single_device))
+      call MPI_Allreduce(temp_bool, this%apply_autotune_reorder, 1, mpi_logical, mpi_land, mpi_comm_world, mpi_ierr)
+    end block
+    this%initialized            = .true.
+
+  end subroutine
+
+  subroutine diezdecomp_update_order_intermediate(this, abs_reorder, mode_send)
+    integer                        ::  k, reorder_send(0:2), reorder_recv(0:2), abs_reorder(0:2)
+    type(diezdecomp_props_transp)  ::  this
+    logical, optional              ::  mode_send
+    logical                        ::  to_send, to_recv
+
+    to_send = .true.
+    to_recv = .true.
+    if (present(mode_send)) then
+      to_send = (     mode_send)
+      to_recv = (.not.mode_send)
+    end if
+
+    if (to_send.and.to_recv) this%chosen_reorder(0:2) = abs_reorder(0:2)
+
+    if (.not.((minval(abs_reorder)==0).and.(maxval(abs_reorder) == 2).and.(sum(abs_reorder) == 3))) then
+      error stop '((minval(abs_reorder) < 0).or.(minval(abs_reorder) == maxval(abs_reorder)))'
+    end if
+    if (to_send) then
+      do k=0,2
+        reorder_send(k) = diezdecomp_get_index_int2int(this%order_a, abs_reorder(k))
+      end do
+      call get_i2b_Mij(this%send_i2b_Mij, this%order_a, abs_reorder)
+      call detailed_block_info(reorder_send     , this%send_pos_start, &
+                               this%send_i0_st  , this%send_i1_st    , this%send_i2_st  , this%send_lshape,&
+                               this%send_b_i0   , this%send_b_i1     , this%send_b_i2   , &
+                               this%send_all_n0 , this%send_all_n1   , this%send_all_n2 , this%send_all_pos_start)
+      this%send_mode_op_batched = -1 ! mode_op: 1 <-> 6
+      this%send_mode_op_simul   = -1 ! mode_op: 1 <-> 6
+      this%send_autotuned       = -1 ! [mode_op chosen -1/1, simultaneous = 1/batched = 2]
+    end if
+    if (to_recv) then
+      do k=0,2
+        reorder_recv(k) = diezdecomp_get_index_int2int(this%order_b, abs_reorder(k))
+      end do
+      call get_i2b_Mij(this%recv_i2b_Mij, this%order_b, abs_reorder)
+      call detailed_block_info(reorder_recv     , this%recv_pos_start, &
+                               this%recv_i0_st  , this%recv_i1_st    , this%recv_i2_st   , this%recv_lshape,&
+                               this%recv_b_i0   , this%recv_b_i1     , this%recv_b_i2    , &
+                               this%recv_all_n0 , this%recv_all_n1   , this%recv_all_n2  , this%recv_all_pos_start)
+      this%recv_mode_op_batched = -1 ! mode_op: 1 <-> 6
+      this%recv_mode_op_simul   = -1 ! mode_op: 1 <-> 6
+      this%recv_autotuned       = -1 ! [mode_op chosen -1/1, simultaneous = 1/batched = 2]
+    end if
+  end subroutine
+
+  subroutine diezdecomp_transp_execute(this, p_in, p_out, stream, buffer)
+    implicit none
+    type(diezdecomp_props_transp)   :: this
+    real(rp), target                :: p_in(0:*), p_out(0:*)
+    real(rp), target, optional      :: buffer(0:)
+    real(rp), pointer, dimension(:) :: buf_in, buf_out
+    integer(acc_handle_kind)        :: stream
+    associate(s0 => this%numel_p_in  , &
+              s1 => this%numel_p_out )
+      if (present(buffer)) then
+          buf_in (0:s0-1) => buffer(0 : s0   -1 )
+          buf_out(0:s1-1) => buffer(s0:(s0+s1-1))
+      else
+          buf_in (0:s0-1) => p_out(0:s0-1)
+          buf_out(0:s1-1) => p_in (0:s1-1)
+      end if
+    end associate
+
+    call wrapper_batched_transpose(this, p_in, buf_in, .true., this%offset6_in, this%elapsed_time_reorder, stream)
+
+    if (.not.this%chosen_backend) call comm_choose_backend(this, buf_out, buf_in, stream)
+    if (this%use_alltoallv) then
+      call comm_transpose_mpi_alltoallv(this, buf_out, buf_in, stream)
+    else
+      call comm_transpose_imode(this, buf_out, buf_in, this%use_nccl, stream)
+    endif
+
+    call wrapper_batched_transpose(this, p_out, buf_out, .false., this%offset6_out, this%elapsed_time_reorder, stream)
+
+    if (this%apply_autotune_reorder) then
+      block
+        integer  :: i,j,k, abs_order(0:2),pos,mpi_ierr
+        real(rp) :: elapsed_best, temp_real
+        elapsed_best = LARGE
+        do pos=0,5
+          i = this%reorder_ijk(0,pos)
+          j = this%reorder_ijk(1,pos)
+          k = this%reorder_ijk(2,pos)
+          temp_real = this%elapsed_time_reorder(pos)/(this%nproc*1._dp)
+          call MPI_Allreduce(temp_real, this%elapsed_time_reorder(pos), 1, MPI_REAL_RP, mpi_sum, mpi_comm_world, mpi_ierr)
+          if (this%elapsed_time_reorder(pos)<elapsed_best) then
+            elapsed_best = this%elapsed_time_reorder(pos)
+            abs_order    = [i,j,k]
+            call diezdecomp_update_order_intermediate(this, abs_order)
+            this%send_mode_op_batched   = this%best_send_mode_op_batched(pos)
+            this%send_mode_op_simul     = this%best_send_mode_op_simul(pos)
+            this%send_autotuned         = this%best_send_autotuned(pos)
+            this%recv_mode_op_batched   = this%best_recv_mode_op_batched(pos)
+            this%recv_mode_op_simul     = this%best_recv_mode_op_simul(pos)
+            this%recv_autotuned         = this%best_recv_autotuned(pos)
+          end if
+        end do
+        !$acc wait(stream)
+        this%apply_autotune_reorder = .false.
+      end block
+    end if
+  end subroutine
+
+  ! ---------------------------------------- batched transpose implementations ------------------------------------------------
+
+  recursive subroutine wrapper_batched_transpose(this, p_in, p_out, mode_fwd, offset6, elapsed_time_reorder, stream)
+    implicit none
+    real(rp)                      ::  p_in(0:*), p_out(0:*), elapsed_time_reorder(0:5), elapsed_time, temp_wtime,temp_x6(0:5)
+    type(diezdecomp_props_transp) ::  this
+    logical                       ::  mode_fwd
+    integer                       ::  pos,iter1,abs_reorder(0:2), offset6(0:2,0:1)
+    integer(acc_handle_kind)      ::  stream
+
+    if (this%apply_autotune_reorder) then
+      this%apply_autotune_reorder = .false.
+      if (mode_fwd) elapsed_time_reorder = 0
+      do pos=0,5
+        abs_reorder(0:2) = this%reorder_ijk(0:2,pos)
+        !$acc wait(stream)
+        call diezdecomp_update_order_intermediate(this, abs_reorder, mode_fwd)
+        call wrapper_batched_transpose(this, p_in, p_out, mode_fwd, offset6, temp_x6, stream)
+        !$acc wait(stream)
+        if (diezdecomp_mode_bench_avg) then ; elapsed_time = 0.
+        else                                ; elapsed_time = LARGE ; end if
+        do iter1 = 1,diezdecomp_autotune_mode_trials
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime()
+          call wrapper_batched_transpose(this, p_in, p_out, mode_fwd, offset6, temp_x6, stream)
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime() - temp_wtime
+          if (diezdecomp_mode_bench_avg) then
+            elapsed_time = elapsed_time + temp_wtime/(diezdecomp_autotune_mode_trials*1._dp)
+          else
+            elapsed_time = min(elapsed_time, temp_wtime)
+          end if
+        end do
+        elapsed_time_reorder(pos) = elapsed_time_reorder(pos) + elapsed_time
+        if (mode_fwd) then
+          this%best_send_mode_op_batched(pos) = this%send_mode_op_batched
+          this%best_send_mode_op_simul(pos)   = this%send_mode_op_simul
+          this%best_send_autotuned(pos)       = this%send_autotuned
+        else
+          this%best_recv_mode_op_batched(pos) = this%recv_mode_op_batched
+          this%best_recv_mode_op_simul(pos)   = this%recv_mode_op_simul
+          this%best_recv_autotuned(pos)       = this%recv_autotuned
+        end if
+      end do
+      this%apply_autotune_reorder = .true.
+    else
+      if (mode_fwd) then
+        call wrapper_batched_transpose_inner(this%send_sizes, p_in, p_out, .true., offset6, &
+                                             this%send_mode_op_batched, this%send_lshape, &
+                                             this%send_i0_st, this%send_i1_st, this%send_i2_st, &
+                                             this%send_b_i0, this%send_b_i1, this%send_b_i2, &
+                                             this%send_i2b_s0   , this%send_i2b_s1   , this%send_i2b_s2, &
+                                             this%send_i2b_i0a, this%send_i2b_i1a, this%send_i2b_i2a, this%send_i2b_Mij, &
+                                             this%send_all_n0, this%send_all_n1, this%send_all_n2, this%send_all_pos_start, &
+                                             this%send_mode_op_simul, this%send_autotuned, &
+                                             this%sp_in_0, this%sp_in_1, this%sp_in_2, &
+                                             this%send_elapsed_batched_top, this%send_elapsed_simul_top, &
+                                             this%send_elapsed_batched_modes, &
+                                             this%send_elapsed_simul_modes, &
+                                             stream)
+      else
+        call wrapper_batched_transpose_inner(this%recv_sizes, p_in, p_out, .false., offset6, &
+                                             this%recv_mode_op_batched, this%recv_lshape, &
+                                             this%recv_i0_st, this%recv_i1_st, this%recv_i2_st, &
+                                             this%recv_b_i0, this%recv_b_i1, this%recv_b_i2, &
+                                             this%recv_i2b_s0   , this%recv_i2b_s1   , this%recv_i2b_s2   , &
+                                             this%recv_i2b_i0a, this%recv_i2b_i1a, this%recv_i2b_i2a, this%recv_i2b_Mij, &
+                                             this%recv_all_n0, this%recv_all_n1, this%recv_all_n2, this%recv_all_pos_start, &
+                                             this%recv_mode_op_simul, this%recv_autotuned, &
+                                             this%sp_out_0, this%sp_out_1, this%sp_out_2, &
+                                             this%recv_elapsed_batched_top, this%recv_elapsed_simul_top, &
+                                             this%recv_elapsed_batched_modes, &
+                                             this%recv_elapsed_simul_modes, &
+                                             stream)
+      end if
+    end if
+    !$acc wait(stream)
+  endsubroutine
+
+  subroutine wrapper_batched_transpose_inner(sizes, p_in, p_out, mode_fwd, offset6, mode_op_batched, loc_shape, &
+                                                 i0_start, i1_start, i2_start, block_i0, block_i1, block_i2, &
+                                                 i2b_s0, i2b_s1, i2b_s2, &
+                                                 i2b_i0a, i2b_i1a, i2b_i2a, i2b_Mij, &
+                                                 all_n0, all_n1, all_n2, all_pos_start, mode_op_simul, mode_transp, &
+                                                 sp_in_0, sp_in_1, sp_in_2, &
+                                                 elapsed_batched_top, elapsed_simul_top, elapsed_batched_modes, &
+                                                 elapsed_simul_modes, &
+                                                 stream)
+    implicit none
+    real(rp) :: p_in(0:*), p_out(0:*)
+    logical  :: mode_fwd
+    integer  :: iter0, iter1, pos, &
+                i0_start(0:), i1_start(0:), i2_start(0:), block_i0(0:), block_i1(0:), block_i2(0:), &
+                i2b_s0(0:) , i2b_s1(0:) , i2b_s2(0:) , offset6(0:2,0:1), &
+                i2b_i0a(0:), i2b_i1a(0:), i2b_i2a(0:), i2b_Mij(0:2,0:2), lshape(0:2), &
+                all_n0(0:,0:,0:), all_n1(0:,0:,0:), all_n2(0:,0:,0:), all_pos_start(0:,0:,0:), mode_transp, &
+                mode_op_batched, sizes(0:), loc_shape(0:,0:), mode_op_simul, sp_in_0, sp_in_1, sp_in_2
+    real(rp) :: elapsed_time, temp_wtime, elapsed_batched_top, elapsed_simul_top, elapsed_transp, &
+                elapsed_batched_modes(0:) , elapsed_simul_modes(0:)
+    integer(acc_handle_kind) :: stream
+    logical  :: choose_mode_transp, choose_mode_batched, choose_mode_simul
+
+    elapsed_transp      = LARGE
+    choose_mode_transp  = ((mode_transp    <1).or.(mode_transp    >2))
+    choose_mode_simul   = ((mode_op_simul  <1).or.(mode_op_simul  >6))
+    choose_mode_batched = ((mode_op_batched<1).or.(mode_op_batched>6))
+
+    if (choose_mode_simul.or.choose_mode_transp) then
+      elapsed_batched_top = LARGE
+      do iter0  = 3,6
+        if (diezdecomp_mode_bench_avg) then ; elapsed_time = 0.
+        else                                ; elapsed_time = LARGE ; end if
+        do iter1 = 1,diezdecomp_autotune_mode_trials
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime()
+          call flat_3d_transpose_simultaneous(p_in, p_out, mode_fwd, offset6, iter0, &
+                                              i2b_s0, i2b_s1, i2b_s2, &
+                                              i2b_i0a, i2b_i1a, i2b_i2a, i2b_Mij, &
+                                              sp_in_0, sp_in_1, sp_in_2, stream)
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime() - temp_wtime
+          if (diezdecomp_mode_bench_avg) then
+            elapsed_time = elapsed_time + temp_wtime/(diezdecomp_autotune_mode_trials*1._dp)
+          else
+            elapsed_time = min(elapsed_time, temp_wtime)
+          end if
+        end do
+        elapsed_simul_modes(iter0-1) = elapsed_time
+        if (elapsed_time < elapsed_batched_top) then
+          if (choose_mode_simul) mode_op_simul = iter0
+          elapsed_batched_top                         = elapsed_time
+        end if
+      end do
+      if (elapsed_batched_top < elapsed_transp) then
+        if (choose_mode_transp) mode_transp = 1
+        elapsed_transp                      = elapsed_batched_top
+      end if
+    end if
+
+    if (choose_mode_batched.or.choose_mode_transp) then
+      elapsed_simul_top = LARGE
+      do iter0  = 3,6
+        if (diezdecomp_mode_bench_avg) then ; elapsed_time = 0.
+        else                                ; elapsed_time = LARGE ; end if
+        do iter1 = 1,diezdecomp_autotune_mode_trials
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime()
+          do pos=0,size(sizes,1)-1
+            lshape = loc_shape(pos,:)
+            call flat_3d_transpose_batched(p_in, p_out, mode_fwd, offset6, iter0, lshape, &
+                                           i0_start(pos), i1_start(pos), &
+                                           i2_start(pos), block_i0(pos), &
+                                           block_i1(pos), block_i2(pos), &
+                                           all_n0, all_n1, all_n2, all_pos_start, sp_in_0, sp_in_1, stream)
+          end do
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime() - temp_wtime
+          if (diezdecomp_mode_bench_avg) then
+            elapsed_time = elapsed_time + temp_wtime/(diezdecomp_autotune_mode_trials*1._dp)
+          else
+            elapsed_time = min(elapsed_time, temp_wtime)
+          end if
+        end do
+        elapsed_batched_modes(iter0-1) =  elapsed_time
+        if (elapsed_time < elapsed_simul_top) then
+          if (choose_mode_batched) mode_op_batched = iter0
+          elapsed_simul_top                             = elapsed_time
+        end if
+      end do
+      if (elapsed_simul_top < elapsed_transp) then
+        if (choose_mode_transp) mode_transp = 2
+        elapsed_transp                      = elapsed_simul_top
+      end if
+    end if
+
+    if (mode_transp == 1) then
+      call flat_3d_transpose_simultaneous(p_in, p_out, mode_fwd, offset6, mode_op_simul, &
+                                          i2b_s0, i2b_s1, i2b_s2, &
+                                          i2b_i0a, i2b_i1a, i2b_i2a, i2b_Mij, &
+                                          sp_in_0, sp_in_1, sp_in_2, stream)
+    else if (mode_transp == 2) then
+      do pos=0,size(sizes,1)-1
+        lshape = loc_shape(pos,:)
+        call flat_3d_transpose_batched(p_in, p_out, mode_fwd, offset6, mode_op_batched, lshape, &
+                                       i0_start(pos), i1_start(pos), &
+                                       i2_start(pos), block_i0(pos), &
+                                       block_i1(pos), block_i2(pos), &
+                                       all_n0, all_n1, all_n2, all_pos_start, sp_in_0, sp_in_1, stream)
+      end do
+    else
+      error stop 'ERROR: autotuning mode not recognized!'
+    end if
+  end subroutine
+
+  subroutine flat_3d_transpose_batched(p_in, p_out, mode_fwd, offset6, mode_op, loc_shape, i0_start, i1_start, i2_start, &
+                                       ib, jb, kb, all_n0, all_n1, all_n2, all_pos_start, sp_in_0, sp_in_1, stream)
+    implicit none
+    real(rp) :: p_out(0:*), p_in(0:*)
+    logical  :: mode_fwd
+    integer  :: i0_start, i1_start, i2_start, ib, jb, kb, pos_start, mode_op, na, nb, sp_in_0, sp_in_1, &
+                i0_last, i1_last, i2_last, di, dj, dk, &
+                all_n0(0:,0:,0:), all_n1(0:,0:,0:), all_n2(0:,0:,0:), all_pos_start(0:,0:,0:), &
+                loc_shape(0:2), n0, n1, n2, i0,i1,i2, offset6(0:2,0:1)
+    integer(acc_handle_kind) :: stream
+    di        = offset6(0,0) ; dj = offset6(1,0) ; dk = offset6(2,0)
+    na        =     sp_in_0 + offset6(0,0) + offset6(0,1)
+    nb        = na*(sp_in_1 + offset6(1,0) + offset6(1,1))
+    n0        = all_n0(ib,jb,kb)
+    n1        = all_n1(ib,jb,kb)
+    n2        = all_n2(ib,jb,kb)
+    pos_start = all_pos_start(ib,jb,kb)
+
+    i2_last   = i2_start + loc_shape(2)-1
+    i1_last   = i1_start + loc_shape(1)-1
+    i0_last   = i0_start + loc_shape(0)-1
+
+    if (mode_fwd) then
+      select case (mode_op)
+      case (1)
+        !$acc parallel loop  collapse(3) default(present) async(stream)
+        do i0 = i0_start, i0_last
+        do i1 = i1_start, i1_last
+        do i2 = i2_start, i2_last
+          p_out(pos_start + i0*n0 + i1*n1 + i2*n2) = p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb)
+        end do
+        end do
+        end do
+      case (2)
+        !$acc parallel loop  collapse(3) default(present) async(stream)
+        do i0 = i0_start, i0_last
+        do i2 = i2_start, i2_last
+        do i1 = i1_start, i1_last
+          p_out(pos_start + i0*n0 + i1*n1 + i2*n2) = p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb)
+        end do
+        end do
+        end do
+      case (3)
+        !$acc parallel loop  collapse(3) default(present) async(stream)
+        do i1 = i1_start, i1_last
+        do i0 = i0_start, i0_last
+        do i2 = i2_start, i2_last
+          p_out(pos_start + i0*n0 + i1*n1 + i2*n2) = p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb)
+        end do
+        end do
+        end do
+      case (4)
+        !$acc parallel loop  collapse(3) default(present) async(stream)
+        do i1 = i1_start, i1_last
+        do i2 = i2_start, i2_last
+        do i0 = i0_start, i0_last
+          p_out(pos_start + i0*n0 + i1*n1 + i2*n2) = p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb)
+        end do
+        end do
+        end do
+      case (5)
+        !$acc parallel loop  collapse(3) default(present) async(stream)
+        do i2 = i2_start, i2_last
+        do i0 = i0_start, i0_last
+        do i1 = i1_start, i1_last
+          p_out(pos_start + i0*n0 + i1*n1 + i2*n2) = p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb)
+        end do
+        end do
+        end do
+      case (6)
+        !$acc parallel loop  collapse(3) default(present) async(stream)
+        do i2 = i2_start, i2_last
+        do i1 = i1_start, i1_last
+        do i0 = i0_start, i0_last
+          p_out(pos_start + i0*n0 + i1*n1 + i2*n2) = p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb)
+        end do
+        end do
+        end do
+      end select
+    else
+      select case (mode_op)
+      case (1)
+        !$acc parallel loop  collapse(3) default(present) async(stream)
+        do i0 = i0_start, i0_last
+        do i1 = i1_start, i1_last
+        do i2 = i2_start, i2_last
+          p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb) = p_out(pos_start + i0*n0 + i1*n1 + i2*n2)
+        end do
+        end do
+        end do
+      case (2)
+        !$acc parallel loop  collapse(3) default(present) async(stream)
+        do i0 = i0_start, i0_last
+        do i2 = i2_start, i2_last
+        do i1 = i1_start, i1_last
+          p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb) = p_out(pos_start + i0*n0 + i1*n1 + i2*n2)
+        end do
+        end do
+        end do
+      case (3)
+        !$acc parallel loop  collapse(3) default(present) async(stream)
+        do i1 = i1_start, i1_last
+        do i0 = i0_start, i0_last
+        do i2 = i2_start, i2_last
+          p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb) = p_out(pos_start + i0*n0 + i1*n1 + i2*n2)
+        end do
+        end do
+        end do
+      case (4)
+        !$acc parallel loop  collapse(3) default(present) async(stream)
+        do i1 = i1_start, i1_last
+        do i2 = i2_start, i2_last
+        do i0 = i0_start, i0_last
+          p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb) = p_out(pos_start + i0*n0 + i1*n1 + i2*n2)
+        end do
+        end do
+        end do
+      case (5)
+        !$acc parallel loop  collapse(3) default(present) async(stream)
+        do i2 = i2_start, i2_last
+        do i0 = i0_start, i0_last
+        do i1 = i1_start, i1_last
+          p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb) = p_out(pos_start + i0*n0 + i1*n1 + i2*n2)
+        end do
+        end do
+        end do
+      case (6)
+        !$acc parallel loop  collapse(3) default(present) async(stream)
+        do i2 = i2_start, i2_last
+        do i1 = i1_start, i1_last
+        do i0 = i0_start, i0_last
+          p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb) = p_out(pos_start + i0*n0 + i1*n1 + i2*n2)
+        end do
+        end do
+        end do
+      end select
+    end if
+  end subroutine
+
+
+  subroutine flat_3d_transpose_simultaneous(p_in, p_out, mode_fwd, offset6, mode_op, &
+                                            i2b_s0, i2b_s1, i2b_s2, &
+                                            i2b_i0a, i2b_i1a, i2b_i2a, i2b_Mij, &
+                                            sp_in_0, sp_in_1, sp_in_2, stream)
+    implicit none
+    real(rp) :: p_out(0:*), p_in(0:*)
+    logical  :: mode_fwd
+    integer  :: i0_start, i1_start, i2_start, i0_last, i1_last, i2_last, di, dj, dk, &
+                              i0, i1, i2, mode_op, sp_in_0, sp_in_1, sp_in_2, na, nb, &
+                              i2b_s0(0:)   , i2b_s1(0:)   , i2b_s2(0:), &
+                              i2b_i0a(0:), i2b_i1a(0:), i2b_i2a(0:), i2b_Mij(0:2,0:2), &
+                              n0, n1, n2, p, m00, m01, m02, &
+                                             m10, m11, m12, &
+                                             m20, m21, m22, s0,s1,s2, offset6(0:2,0:1), na_in, nb_in
+    integer, parameter :: int1 = 1
+    integer(acc_handle_kind) :: stream
+    i0_start = 0
+    i1_start = 0
+    i2_start = 0
+    i0_last  = sp_in_0-1
+    i1_last  = sp_in_1-1
+    i2_last  = sp_in_2-1
+    di       = offset6(0,0) ; dj = offset6(1,0) ; dk = offset6(2,0)
+    na       =     sp_in_0 + offset6(0,0) + offset6(0,1)
+    nb       = na*(sp_in_1 + offset6(1,0) + offset6(1,1))
+    na_in    = sp_in_0
+    nb_in    = sp_in_0 * sp_in_1
+    m00      = i2b_Mij(0,0)
+    m01      = i2b_Mij(0,1)
+    m02      = i2b_Mij(0,2)
+    m10      = i2b_Mij(1,0)
+    m11      = i2b_Mij(1,1)
+    m12      = i2b_Mij(1,2)
+    m20      = i2b_Mij(2,0)
+    m21      = i2b_Mij(2,1)
+    m22      = i2b_Mij(2,2)
+    if (mode_fwd) then
+      select case (mode_op)
+      case (1)
+        !$acc parallel loop  collapse(3) default(present) private(i0,i1,i2,s0,s1,s2,n0,n1,n2,p) async(stream)
+        do i0 = i0_start, i0_last
+        do i1 = i1_start, i1_last
+        do i2 = i2_start, i2_last
+          s0  = i2b_s0(i0) ; s1  = i2b_s1(i1) ; s2  = i2b_s2(i2)
+          n0 = (int1+m00*(s0-int1))*(int1+m01*(s1-int1))*(int1+m02*(s2-int1))
+          n1 = (int1+m10*(s0-int1))*(int1+m11*(s1-int1))*(int1+m12*(s2-int1))
+          n2 = (int1+m20*(s0-int1))*(int1+m21*(s1-int1))*(int1+m22*(s2-int1))
+          p = (nb_in-n2)*i2b_i2a(i2) + (na_in*s2-n1)*i2b_i1a(i1) + (s1*s2-n0)*i2b_i0a(i0)
+          p_out(p + i0*n0 + i1*n1 + i2*n2) = p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb)
+        end do
+        end do
+        end do
+      case (2)
+        !$acc parallel loop  collapse(3) default(present) private(i0,i1,i2,s0,s1,s2,n0,n1,n2,p) async(stream)
+        do i0 = i0_start, i0_last
+        do i2 = i2_start, i2_last
+        do i1 = i1_start, i1_last
+          s0  = i2b_s0(i0) ; s1  = i2b_s1(i1) ; s2  = i2b_s2(i2)
+          n0 = (int1+m00*(s0-int1))*(int1+m01*(s1-int1))*(int1+m02*(s2-int1))
+          n1 = (int1+m10*(s0-int1))*(int1+m11*(s1-int1))*(int1+m12*(s2-int1))
+          n2 = (int1+m20*(s0-int1))*(int1+m21*(s1-int1))*(int1+m22*(s2-int1))
+          p = (nb_in-n2)*i2b_i2a(i2) + (na_in*s2-n1)*i2b_i1a(i1) + (s1*s2-n0)*i2b_i0a(i0)
+          p_out(p + i0*n0 + i1*n1 + i2*n2) = p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb)
+        end do
+        end do
+        end do
+      case (3)
+        !$acc parallel loop  collapse(3) default(present) private(i0,i1,i2,s0,s1,s2,n0,n1,n2,p) async(stream)
+        do i1 = i1_start, i1_last
+        do i0 = i0_start, i0_last
+        do i2 = i2_start, i2_last
+          s0  = i2b_s0(i0) ; s1  = i2b_s1(i1) ; s2  = i2b_s2(i2)
+          n0 = (int1+m00*(s0-int1))*(int1+m01*(s1-int1))*(int1+m02*(s2-int1))
+          n1 = (int1+m10*(s0-int1))*(int1+m11*(s1-int1))*(int1+m12*(s2-int1))
+          n2 = (int1+m20*(s0-int1))*(int1+m21*(s1-int1))*(int1+m22*(s2-int1))
+          p = (nb_in-n2)*i2b_i2a(i2) + (na_in*s2-n1)*i2b_i1a(i1) + (s1*s2-n0)*i2b_i0a(i0)
+          p_out(p + i0*n0 + i1*n1 + i2*n2) = p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb)
+        end do
+        end do
+        end do
+      case (4)
+        !$acc parallel loop  collapse(3) default(present) private(i0,i1,i2,s0,s1,s2,n0,n1,n2,p) async(stream)
+        do i1 = i1_start, i1_last
+        do i2 = i2_start, i2_last
+        do i0 = i0_start, i0_last
+          s0  = i2b_s0(i0) ; s1  = i2b_s1(i1) ; s2  = i2b_s2(i2)
+          n0 = (int1+m00*(s0-int1))*(int1+m01*(s1-int1))*(int1+m02*(s2-int1))
+          n1 = (int1+m10*(s0-int1))*(int1+m11*(s1-int1))*(int1+m12*(s2-int1))
+          n2 = (int1+m20*(s0-int1))*(int1+m21*(s1-int1))*(int1+m22*(s2-int1))
+          p = (nb_in-n2)*i2b_i2a(i2) + (na_in*s2-n1)*i2b_i1a(i1) + (s1*s2-n0)*i2b_i0a(i0)
+          p_out(p + i0*n0 + i1*n1 + i2*n2) = p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb)
+        end do
+        end do
+        end do
+      case (5)
+        !$acc parallel loop  collapse(3) default(present) private(i0,i1,i2,s0,s1,s2,n0,n1,n2,p) async(stream)
+        do i2 = i2_start, i2_last
+        do i0 = i0_start, i0_last
+        do i1 = i1_start, i1_last
+          s0  = i2b_s0(i0) ; s1  = i2b_s1(i1) ; s2  = i2b_s2(i2)
+          n0 = (int1+m00*(s0-int1))*(int1+m01*(s1-int1))*(int1+m02*(s2-int1))
+          n1 = (int1+m10*(s0-int1))*(int1+m11*(s1-int1))*(int1+m12*(s2-int1))
+          n2 = (int1+m20*(s0-int1))*(int1+m21*(s1-int1))*(int1+m22*(s2-int1))
+          p = (nb_in-n2)*i2b_i2a(i2) + (na_in*s2-n1)*i2b_i1a(i1) + (s1*s2-n0)*i2b_i0a(i0)
+          p_out(p + i0*n0 + i1*n1 + i2*n2) = p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb)
+        end do
+        end do
+        end do
+      case (6)
+        !$acc parallel loop  collapse(3) default(present) private(i0,i1,i2,s0,s1,s2,n0,n1,n2,p) async(stream)
+        do i2 = i2_start, i2_last
+        do i1 = i1_start, i1_last
+        do i0 = i0_start, i0_last
+          s0  = i2b_s0(i0) ; s1  = i2b_s1(i1) ; s2  = i2b_s2(i2)
+          n0 = (int1+m00*(s0-int1))*(int1+m01*(s1-int1))*(int1+m02*(s2-int1))
+          n1 = (int1+m10*(s0-int1))*(int1+m11*(s1-int1))*(int1+m12*(s2-int1))
+          n2 = (int1+m20*(s0-int1))*(int1+m21*(s1-int1))*(int1+m22*(s2-int1))
+          p = (nb_in-n2)*i2b_i2a(i2) + (na_in*s2-n1)*i2b_i1a(i1) + (s1*s2-n0)*i2b_i0a(i0)
+          p_out(p + i0*n0 + i1*n1 + i2*n2) = p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb)
+        end do
+        end do
+        end do
+      end select
+    else
+      select case (mode_op)
+      case (1)
+        !$acc parallel loop  collapse(3) default(present) private(i0,i1,i2,s0,s1,s2,n0,n1,n2,p) async(stream)
+        do i0 = i0_start, i0_last
+        do i1 = i1_start, i1_last
+        do i2 = i2_start, i2_last
+          s0  = i2b_s0(i0) ; s1  = i2b_s1(i1) ; s2  = i2b_s2(i2)
+          n0 = (int1+m00*(s0-int1))*(int1+m01*(s1-int1))*(int1+m02*(s2-int1))
+          n1 = (int1+m10*(s0-int1))*(int1+m11*(s1-int1))*(int1+m12*(s2-int1))
+          n2 = (int1+m20*(s0-int1))*(int1+m21*(s1-int1))*(int1+m22*(s2-int1))
+          p = (nb_in-n2)*i2b_i2a(i2) + (na_in*s2-n1)*i2b_i1a(i1) + (s1*s2-n0)*i2b_i0a(i0)
+          p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb) = p_out(p + i0*n0 + i1*n1 + i2*n2)
+        end do
+        end do
+        end do
+      case (2)
+        !$acc parallel loop  collapse(3) default(present) private(i0,i1,i2,s0,s1,s2,n0,n1,n2,p) async(stream)
+        do i0 = i0_start, i0_last
+        do i2 = i2_start, i2_last
+        do i1 = i1_start, i1_last
+          s0  = i2b_s0(i0) ; s1  = i2b_s1(i1) ; s2  = i2b_s2(i2)
+          n0 = (int1+m00*(s0-int1))*(int1+m01*(s1-int1))*(int1+m02*(s2-int1))
+          n1 = (int1+m10*(s0-int1))*(int1+m11*(s1-int1))*(int1+m12*(s2-int1))
+          n2 = (int1+m20*(s0-int1))*(int1+m21*(s1-int1))*(int1+m22*(s2-int1))
+          p = (nb_in-n2)*i2b_i2a(i2) + (na_in*s2-n1)*i2b_i1a(i1) + (s1*s2-n0)*i2b_i0a(i0)
+          p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb) = p_out(p + i0*n0 + i1*n1 + i2*n2)
+        end do
+        end do
+        end do
+      case (3)
+        !$acc parallel loop  collapse(3) default(present) private(i0,i1,i2,s0,s1,s2,n0,n1,n2,p) async(stream)
+        do i1 = i1_start, i1_last
+        do i0 = i0_start, i0_last
+        do i2 = i2_start, i2_last
+          s0  = i2b_s0(i0) ; s1  = i2b_s1(i1) ; s2  = i2b_s2(i2)
+          n0 = (int1+m00*(s0-int1))*(int1+m01*(s1-int1))*(int1+m02*(s2-int1))
+          n1 = (int1+m10*(s0-int1))*(int1+m11*(s1-int1))*(int1+m12*(s2-int1))
+          n2 = (int1+m20*(s0-int1))*(int1+m21*(s1-int1))*(int1+m22*(s2-int1))
+          p = (nb_in-n2)*i2b_i2a(i2) + (na_in*s2-n1)*i2b_i1a(i1) + (s1*s2-n0)*i2b_i0a(i0)
+          p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb) = p_out(p + i0*n0 + i1*n1 + i2*n2)
+        end do
+        end do
+        end do
+      case (4)
+        !$acc parallel loop  collapse(3) default(present) private(i0,i1,i2,s0,s1,s2,n0,n1,n2,p) async(stream)
+        do i1 = i1_start, i1_last
+        do i2 = i2_start, i2_last
+        do i0 = i0_start, i0_last
+          s0  = i2b_s0(i0) ; s1  = i2b_s1(i1) ; s2  = i2b_s2(i2)
+          n0 = (int1+m00*(s0-int1))*(int1+m01*(s1-int1))*(int1+m02*(s2-int1))
+          n1 = (int1+m10*(s0-int1))*(int1+m11*(s1-int1))*(int1+m12*(s2-int1))
+          n2 = (int1+m20*(s0-int1))*(int1+m21*(s1-int1))*(int1+m22*(s2-int1))
+          p = (nb_in-n2)*i2b_i2a(i2) + (na_in*s2-n1)*i2b_i1a(i1) + (s1*s2-n0)*i2b_i0a(i0)
+          p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb) = p_out(p + i0*n0 + i1*n1 + i2*n2)
+        end do
+        end do
+        end do
+      case (5)
+        !$acc parallel loop  collapse(3) default(present) private(i0,i1,i2,s0,s1,s2,n0,n1,n2,p) async(stream)
+        do i2 = i2_start, i2_last
+        do i0 = i0_start, i0_last
+        do i1 = i1_start, i1_last
+          s0  = i2b_s0(i0) ; s1  = i2b_s1(i1) ; s2  = i2b_s2(i2)
+          n0 = (int1+m00*(s0-int1))*(int1+m01*(s1-int1))*(int1+m02*(s2-int1))
+          n1 = (int1+m10*(s0-int1))*(int1+m11*(s1-int1))*(int1+m12*(s2-int1))
+          n2 = (int1+m20*(s0-int1))*(int1+m21*(s1-int1))*(int1+m22*(s2-int1))
+          p = (nb_in-n2)*i2b_i2a(i2) + (na_in*s2-n1)*i2b_i1a(i1) + (s1*s2-n0)*i2b_i0a(i0)
+          p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb) = p_out(p + i0*n0 + i1*n1 + i2*n2)
+        end do
+        end do
+        end do
+      case (6)
+        !$acc parallel loop  collapse(3) default(present) private(i0,i1,i2,s0,s1,s2,n0,n1,n2,p) async(stream)
+        do i2 = i2_start, i2_last
+        do i1 = i1_start, i1_last
+        do i0 = i0_start, i0_last
+          s0  = i2b_s0(i0) ; s1  = i2b_s1(i1) ; s2  = i2b_s2(i2)
+          n0 = (int1+m00*(s0-int1))*(int1+m01*(s1-int1))*(int1+m02*(s2-int1))
+          n1 = (int1+m10*(s0-int1))*(int1+m11*(s1-int1))*(int1+m12*(s2-int1))
+          n2 = (int1+m20*(s0-int1))*(int1+m21*(s1-int1))*(int1+m22*(s2-int1))
+          p = (nb_in-n2)*i2b_i2a(i2) + (na_in*s2-n1)*i2b_i1a(i1) + (s1*s2-n0)*i2b_i0a(i0)
+          p_in((i0+di)+(i1+dj)*na+(i2+dk)*nb) = p_out(p + i0*n0 + i1*n1 + i2*n2)
+        end do
+        end do
+        end do
+      end select
+    end if
+  end subroutine
+
+
+  ! ---------------------------------------- transpose auxiliary functions ------------------------------------------------
+
+  subroutine  transp_match_intervals(lo_a, hi_a, all_lo_b, all_hi_b, &
+                                     temp_buffer, temp_buffer_sort, &
+                                     i, nproc, loc_order_a, loc_order_b)
+    implicit none
+    integer :: lo_a(0:), hi_a(0:), all_lo_b(0:,0:), all_hi_b(0:,0:), &
+               temp_buffer(0:,0:), temp_buffer_sort(0:,0:), temp_lo(0:2), temp_hi(0:2), &
+               i,j,k, nproc, &
+               loc_order_a(0:2), loc_order_b(0:2), reorder(0:2)
+    do j=0,2
+      reorder(j) = diezdecomp_get_index_int2int(loc_order_b, loc_order_a(j))
+    end do
+    i = 0
+    do k=0,nproc-1
+      do j=0,2
+        temp_lo(j) = max(lo_a(j), all_lo_b(reorder(j),k))
+        temp_hi(j) = min(hi_a(j), all_hi_b(reorder(j),k))
+      end do
+      if ((temp_lo(0) <= temp_hi(0)).and.&
+          (temp_lo(1) <= temp_hi(1)).and.&
+          (temp_lo(2) <= temp_hi(2))) then
+        temp_buffer(i,0:2) = temp_lo
+        temp_buffer(i,3)   = k
+        temp_buffer(i,4:6) = temp_hi - temp_lo + 1
+        i                  = i + 1
+      end if
+    end do
+    i = i - 1
+    block
+      integer :: ip,p
+      do ip=0,i
+        p                 = temp_buffer(ip,0)
+        temp_buffer(ip,0) = temp_buffer(ip,2)
+        temp_buffer(ip,2) = p
+      end do
+    call mergesort_rows(temp_buffer, 0, i+0, temp_buffer_sort)
+      do ip=0,i
+        p                 = temp_buffer(ip,0)
+        temp_buffer(ip,0) = temp_buffer(ip,2)
+        temp_buffer(ip,2) = p
+      end do
+    end block
+  end subroutine
+
+  subroutine detailed_block_info(reorder, pos_start0, i0_start, i1_start, i2_start, loc_shape, block_i0, block_i1, block_i2, &
+                                 all_n0, all_n1, all_n2, all_pos_start)
+    implicit none
+    integer :: pos, ib, jb, kb, reorder_inv(0:2), shape_aux(0:3), reorder(0:2), &
+               pos_start0(0:), i0_start(0:), i1_start(0:), i2_start(0:), loc_shape(0:,0:), &
+               block_i0(0:), block_i1(0:), block_i2(0:), &
+               all_n0(0:,0:,0:), all_n1(0:,0:,0:), all_n2(0:,0:,0:), all_pos_start(0:,0:,0:)
+      do pos=0,size(i0_start,1)-1
+        reorder_inv = (/ reorder(2), reorder(1), reorder(0) /)
+        shape_aux = (/ loc_shape(pos,reorder_inv(0)), loc_shape(pos,reorder_inv(1)), loc_shape(pos,reorder_inv(2)), 1 /)
+        ib = block_i0(pos)
+        jb = block_i1(pos)
+        kb = block_i2(pos)
+        all_n0(ib,jb,kb) = product(shape_aux(diezdecomp_get_index_int2int(reorder_inv,0)+1:))
+        all_n1(ib,jb,kb) = product(shape_aux(diezdecomp_get_index_int2int(reorder_inv,1)+1:))
+        all_n2(ib,jb,kb) = product(shape_aux(diezdecomp_get_index_int2int(reorder_inv,2)+1:))
+        all_pos_start(ib,jb,kb) = pos_start0(pos) - (i0_start(pos)*all_n0(ib,jb,kb) + &
+                                                     i1_start(pos)*all_n1(ib,jb,kb) + &
+                                                     i2_start(pos)*all_n2(ib,jb,kb))
+      end do
+  end subroutine
+
+  subroutine mk_blocks_1d(i0_start, shape_0, block_i0, i2b_s0, i2b_i0a, buffer, buffer_sort)
+    implicit none
+    integer :: i0_start(0:), shape_0(0:), block_i0(0:), i2b_s0(0:), i2b_i0a(0:), buffer(0:,0:), buffer_sort(0:,0:),&
+    last,i,k,prev,myid
+    last = size(i0_start,1)-1
+    do k=0,last
+      buffer(k,:) = [i0_start(k), k]
+    end do
+    call mergesort_rows(buffer, 0, last, buffer_sort)
+    myid = -1
+    prev = -1
+    do k=0,last
+      if (buffer(k,0) > prev) myid = myid + 1
+      block_i0(buffer(k,1)) = myid
+      prev = buffer(k,0)
+    end do
+    do k=0,last
+      do i=i0_start(k),i0_start(k)+shape_0(k)-1
+        i2b_s0(i)  = shape_0(k)
+        i2b_i0a(i) = i0_start(k)
+      end do
+    end do
+  end subroutine
+
+  subroutine get_i2b_Mij(m, s, t)
+    integer :: m(0:2,0:2), s(0:2), t(0:2),i,j,a,b
+    m = 0
+    do i=0,2
+      a = diezdecomp_get_index_int2int(t,s(i))
+      if ((a-1)>=0) then
+        do j=0,a-1
+          b = diezdecomp_get_index_int2int(s,t(j))
+          m(i,b) = 1
+        end do
+      end if
+    end do
+  end subroutine
+
+  ! ---------------------------------------- communication auxiliary routines ------------------------------------------------
+
+  subroutine comm_choose_backend(this, buffer, p_out, stream)
+    implicit none
+    type(diezdecomp_props_transp) :: this
+    real(rp)                 :: buffer(0:*)
+    real(rp)                 :: p_out(0:*)
+    integer                  :: pos, n_active, mode_best, mpi_ierr
+    real(dp)                 :: elapsed_best, elapsed_alltoallv, elapsed_isendirecv, elapsed_nccl, temp_real, temp_wtime
+    integer(acc_handle_kind) :: stream
+    this%chosen_backend = .true.
+    n_active = 0
+    if (this%use_alltoallv)  n_active = n_active + 1
+    if (this%use_isendirecv) n_active = n_active + 1
+    if (this%use_nccl)       n_active = n_active + 1
+    elapsed_best       = LARGE
+    elapsed_alltoallv  = LARGE
+    elapsed_isendirecv = LARGE
+    elapsed_nccl       = LARGE
+    mode_best          = 2
+    if (n_active>1) then
+      if (this%use_alltoallv) then
+        do pos=1,diezdecomp_n_warmup ; call comm_transpose_mpi_alltoallv(this, buffer, p_out, stream) ; end do
+        if (diezdecomp_mode_bench_avg) then ; elapsed_alltoallv = 0.
+        else                                ; elapsed_alltoallv = LARGE ; end if
+        do pos=1,diezdecomp_autotune_mode_trials
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime()
+          call comm_transpose_mpi_alltoallv(this, buffer, p_out, stream)
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime() - temp_wtime
+          if (diezdecomp_mode_bench_avg) then
+            elapsed_alltoallv = elapsed_alltoallv + temp_wtime/(diezdecomp_autotune_mode_trials*1._dp)
+          else
+            elapsed_alltoallv = min(elapsed_alltoallv, temp_wtime)
+          end if
+        end do
+        temp_real = elapsed_alltoallv/(this%nproc*1._dp)
+        call MPI_Allreduce(temp_real, elapsed_alltoallv, 1, MPI_DOUBLE_PRECISION, mpi_sum, mpi_comm_world, mpi_ierr)
+        if (elapsed_alltoallv<elapsed_best) mode_best=1
+        elapsed_best            = min(elapsed_best, elapsed_alltoallv)
+        this%elapsed_alltoallv  = elapsed_alltoallv
+      end if
+
+      if (this%use_isendirecv) then
+        do pos=1,diezdecomp_n_warmup ; call comm_transpose_imode(this, buffer, p_out, .false., stream) ; end do
+        if (diezdecomp_mode_bench_avg) then ; elapsed_isendirecv = 0.
+        else                                ; elapsed_isendirecv = LARGE ; end if
+        do pos=1,diezdecomp_autotune_mode_trials
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime()
+          call comm_transpose_imode(this, buffer, p_out, .false., stream)
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime() - temp_wtime
+          if (diezdecomp_mode_bench_avg) then
+            elapsed_isendirecv = elapsed_isendirecv + temp_wtime/(diezdecomp_autotune_mode_trials*1._dp)
+          else
+            elapsed_isendirecv = min(elapsed_isendirecv, temp_wtime)
+          end if
+        end do
+        temp_real = elapsed_isendirecv/(this%nproc*1._dp)
+        call MPI_Allreduce(temp_real, elapsed_isendirecv, 1, MPI_DOUBLE_PRECISION, mpi_sum, mpi_comm_world, mpi_ierr)
+        if (elapsed_isendirecv<elapsed_best) mode_best=2
+        elapsed_best            = min(elapsed_best, elapsed_isendirecv)
+        this%elapsed_isendirecv = elapsed_isendirecv
+      end if
+#if defined(_DIEZDECOMP_NCCL)
+      if (this%use_nccl) then
+        do pos=1,diezdecomp_n_warmup ; call comm_transpose_imode(this, buffer, p_out, .true., stream) ; end do
+        if (diezdecomp_mode_bench_avg) then ; elapsed_nccl = 0.
+        else                                ; elapsed_nccl = LARGE ; end if
+        do pos=1,diezdecomp_autotune_mode_trials
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime()
+          call comm_transpose_imode(this, buffer, p_out, .true., stream)
+          !$acc wait(stream)
+          temp_wtime = MPI_Wtime() - temp_wtime
+          if (diezdecomp_mode_bench_avg) then
+            elapsed_nccl = elapsed_nccl + temp_wtime/(diezdecomp_autotune_mode_trials*1._dp)
+          else
+            elapsed_nccl = min(elapsed_nccl, temp_wtime)
+          end if
+        end do
+        temp_real = elapsed_nccl/(this%nproc*1._dp)
+        call MPI_Allreduce(temp_real, elapsed_nccl, 1, MPI_DOUBLE_PRECISION, mpi_sum, mpi_comm_world, mpi_ierr)
+        if (elapsed_nccl<elapsed_best) mode_best=3
+        elapsed_best      = min(elapsed_best, elapsed_nccl)
+        this%elapsed_nccl = elapsed_nccl
+      end if
+#endif
+      if (mode_best == 1) then ; this%use_alltoallv = .true. ; this%use_isendirecv = .false.; this%use_nccl = .false.;end if
+      if (mode_best == 2) then ; this%use_alltoallv = .false.; this%use_isendirecv = .true. ; this%use_nccl = .false.;end if
+      if (mode_best == 3) then ; this%use_alltoallv = .false.; this%use_isendirecv = .false.; this%use_nccl = .true. ;end if
+      !write(*,*) this%irank, 'chosen backend', mode_best, elapsed_alltoallv, elapsed_isendirecv, elapsed_nccl
+    end if
+  end subroutine
+
+  subroutine comm_transpose_mpi_alltoallv(this, buffer, p_out, stream)
+    implicit none
+    type(diezdecomp_props_transp) :: this
+    real(rp)                 :: buffer(0:*)
+    real(rp)                 :: p_out(0:*)
+    integer                  :: mpi_ierr
+    integer(acc_handle_kind) :: stream
+
+    !$acc wait(stream)
+    !$acc host_data use_device(buffer, p_out)
+    call MPI_Alltoallv(p_out , this%send_sizes, this%send_pos_start, MPI_REAL_RP, &
+                       buffer, this%recv_sizes, this%recv_pos_start, MPI_REAL_RP, &
+                       this%mpi_comm_kk, mpi_ierr)
+    !$acc end host_data
+  end subroutine
+
+  subroutine comm_transpose_imode(this, buffer, p_out, is_nccl, stream)
+    implicit none
+    type(diezdecomp_props_transp) :: this
+    real(rp)                 :: buffer(0:*)
+    real(rp)                 :: p_out(0:*)
+    integer                  :: mpi_ierr, pos, ireq
+    logical                  :: is_nccl
+    integer(acc_handle_kind) :: stream
+    !$acc wait(stream)
+    ireq = 0
+#if defined(_DIEZDECOMP_NCCL)
+    if (is_nccl)  nccl_stat = ncclGroupStart()
+#endif
+    do pos=0,size(this%recv_ids,1)-1
+      if (this%recv_ids(pos) /= this%irank) then
+        call isendrecv_1d_buffer(.false., buffer, this%recv_pos_start(pos), this%recv_sizes(pos), &
+                                 this%recv_ids(pos) , &
+                                 this%recv_tags(pos), mpi_comm_world, this%all_request(ireq), is_nccl)
+        ireq = ireq + 1
+      end if
+    end do
+    do pos=0,size(this%send_ids,1)-1
+      if (this%send_ids(pos) /= this%irank) then
+        call isendrecv_1d_buffer(.true., p_out, this%send_pos_start(pos), this%send_sizes(pos), &
+                                 this%send_ids(pos) , &
+                                 this%send_tags(pos), mpi_comm_world, this%all_request(ireq), is_nccl)
+        ireq = ireq + 1
+      end if
+    end do
+    if ((this%pos_start_localSend>=0).and.(this%pos_start_localRecv>=0)) then
+      call copy_1d_buffer(p_out, buffer, this%pos_start_localSend, this%pos_start_localRecv, this%size_localSend, stream)
+    end if
+#if defined(_DIEZDECOMP_NCCL)
+    if (is_nccl)  then
+      nccl_stat = ncclGroupEnd()
+      mpi_ierr = cudaStreamSynchronize(nccl_stream)
+      ireq = 0 ! nccl did not use ireq
+    end if
+#endif
+    if (ireq>0) call mpi_waitall(ireq, this%all_request, this%all_status, mpi_ierr)
+    !$acc wait(stream)
+  end subroutine
+
+  subroutine isendrecv_1d_buffer(mode_fwd,A,i,s,other,tag,comm,req,is_nccl)
+    implicit none
+    real(rp)          :: A(0:*)
+    integer           :: i,s,other,tag,comm,req, i0,mpi_ierr
+    logical           :: mode_fwd, is_mpi
+    logical, optional :: is_nccl
+    is_mpi = .true.
+#if defined(_DIEZDECOMP_NCCL)
+    if (present(is_nccl))  is_mpi = .not.is_nccl
+#endif
+    i0 = i
+    !$acc host_data use_device(A)
+    if (is_mpi) then
+      if (mode_fwd) then ; call MPI_ISend(A(i0),s, MPI_REAL_RP, other, tag, comm, req, mpi_ierr)
+      else               ; call MPI_IRecv(A(i0),s, MPI_REAL_RP, other, tag, comm, req, mpi_ierr)
+      end if
+#if defined(_DIEZDECOMP_NCCL)
+    else
+      if (mode_fwd) then ; nccl_stat=ncclSend(A(i0),s, ncclDouble, other, nccl_comm, nccl_stream)
+      else               ; nccl_stat=ncclRecv(A(i0),s, ncclDouble, other, nccl_comm, nccl_stream)
+      end if
+#endif
+    end if
+    !$acc end host_data
+  end subroutine
+
+  ! ---------------------------------------- diezdecomp get_ranks -------------------------------------------
+
+  subroutine diezdecomp_fill_mpi_ranks(lo, mpi_ranks, flat_mpi_ranks, shape_mpi_ranks, irank, nproc)
+    implicit none
+    integer              :: lo(0:2), mpi_ierr, irank, nproc, i, j, k, pos, last, shape_mpi_ranks(0:2)
+    integer, allocatable :: buffer(:), full_arr(:,:), buffer_sort(:,:), mpi_ranks(:,:,:), flat_mpi_ranks(:,:)
+
+    ! Notes: 1) lo(0:2) must be the global (i,j,k) position of "irank" in the 3-D pencil decomposition (xyz).
+    !        2) If lo(0:2) has an order different from (ijk or xyz) (e.g., yxz), then it must be converted before
+    !           calling this subroutine (by an API ifle for instance).
+
+    allocate(buffer(0:(nproc*3-1)), full_arr(0:(nproc-1),0:3), buffer_sort(0:(nproc-1),0:3))
+
+    call MPI_Allgather(lo    , 3, mpi_int,&
+                       buffer, 3, mpi_int,&
+                       mpi_comm_world, mpi_ierr)
+    do   i = 0, nproc-1
+      do j = 0, 2
+        full_arr(i,j) = buffer(3*i + j)
+      end do
+      full_arr(i,3) = i ! "i" is irank for this buffer position
+    end do
+
+    ! check if irank matches full_arr data
+    if (maxval(abs(full_arr(irank,0:2)-lo))>0) error stop  'ERROR! full_arr(irank,0:2)' ! , full_arr(irank+1,1:3), lo
+
+    ! sort full_arr (by position)
+    call mergesort_rows(full_arr, 0, nproc-1, buffer_sort)
+
+    ! transform "lo" into ijk
+    do j=0,2
+      last = -1
+      pos  = -1
+      do i=0,nproc-1
+        if (full_arr(i,j) < last) then
+          pos = 0
+        else if (full_arr(i,j) > last) then
+          pos = pos + 1
+        end if
+        last          = full_arr(i,j)
+        full_arr(i,j) = pos
+      end do
+    end do
+
+    if (allocated(mpi_ranks)) deallocate(mpi_ranks)
+    allocate(mpi_ranks(0:maxval(full_arr(:,0)), 0:maxval(full_arr(:,1)), 0:maxval(full_arr(:,2))))
+
+    if (nproc /= (size(mpi_ranks,1)*size(mpi_ranks,2)*size(mpi_ranks,3))) error stop  'ERROR! nproc /= prod(shape(mpi_ranks))'
+
+    do i = 0, nproc-1
+      mpi_ranks(full_arr(i,0),full_arr(i,1),full_arr(i,2)) = full_arr(i,3)
+    end do
+
+    deallocate(buffer, full_arr, buffer_sort)
+
+    ! complete shape_mpi_ranks, flat_mpi_ranks
+      do i=0,2
+        shape_mpi_ranks(i) = size(mpi_ranks,i+1)
+      end do
+
+      if (allocated(flat_mpi_ranks)) deallocate(flat_mpi_ranks)
+      allocate(flat_mpi_ranks(0:nproc-1,0:2))
+
+      do     i=0,size(mpi_ranks,1)-1
+        do   j=0,size(mpi_ranks,2)-1
+          do k=0,size(mpi_ranks,3)-1
+            pos                   = mpi_ranks(i,j,k)
+            flat_mpi_ranks(pos,0) = i
+            flat_mpi_ranks(pos,1) = j
+            flat_mpi_ranks(pos,2) = k
+          end do
+        end do
+      end do
+  end subroutine
+
+  function diezdecomp_get_rank_id(ranks_ii, flat_ranks_ii, shape_ranks_ii, irank, ii, d) result(pos)
+    implicit none
+    integer, intent(in) :: ranks_ii(0:,0:,0:), flat_ranks_ii(0:,0:),shape_ranks_ii(0:2), irank, ii, d
+    integer             :: i,j,k, pos
+
+    ! call check_bounds(ii,  0, 2)
+    ! call check_bounds( d, -1, 1)
+
+    i = flat_ranks_ii(irank,0)
+    j = flat_ranks_ii(irank,1)
+    k = flat_ranks_ii(irank,2)
+    if (ii == 0) i = modulo(i + d,shape_ranks_ii(0))
+    if (ii == 1) j = modulo(j + d,shape_ranks_ii(1))
+    if (ii == 2) k = modulo(k + d,shape_ranks_ii(2))
+    pos = ranks_ii(i,j,k)
+  end function
+
+  function get_position_in_3darr(flat_ranks_ii, irank, ii) result(pos)
+    implicit none
+    integer, intent(in) :: flat_ranks_ii(0:,0:), irank, ii
+    integer             :: pos
+    pos = flat_ranks_ii(irank, ii)
+  end function
+
+  ! ---------------------------------------- general purpose routines ------------------------------------------------
+
+  subroutine copy_1d_buffer(A, B, ia, ib, sa, stream)
+    implicit none
+    real(rp) :: A(0:*), B(0:*)
+    integer  :: i, ia, ib, sa, di
+    integer(acc_handle_kind) :: stream
+
+    if (sa>0) then
+      di = ia - ib
+      !$acc parallel loop  collapse(1) default(present) async(stream)
+      do i = ib, ib+sa-1
+        B(i) = A(i+di)
+      end do
+    end if
+  end subroutine
+
+  ! subroutine check_bounds(x, a, b, key0)
+  !   implicit none
+  !   integer           :: x, a, b, key
+  !   integer, optional :: key0 ! key0 is a hint/identifier about the source call
+  !   key = -1
+  !   if (present(key0)) key = key0
+  !   if (.not.((a <= x).and.(x <= b))) then
+  !     error stop 'ERROR: out-of-bounds' ! , x, a, b, key
+  !   end if
+  ! end subroutine
+
+  function diezdecomp_get_index_int2int(A, ref) result(pos)
+    implicit none
+    ! implementation of python function: pos = list_x.index(value_y)
+    integer :: A(0:), ref, pos
+    pos = findloc(A,ref,dim=1) - 1
+    if (pos == -1) error stop 'ERROR: diezdecomp_get_index_int2int'
+  end function
+
+  function is_greater(a, b) result(res)
+    implicit none
+    logical :: res
+    integer :: a(:), b(:), i
+    res = .false.
+    do i=1,max(size(a,1),size(b,1))
+      if (a(i) > b(i)) then
+        res = .true.
+        return
+      else if (a(i) < b(i)) then
+        res = .false.
+        return
+      end if
+    end do
+    ! reached this line ---> all equal ---> is_greater=false --> ok
+  end function
+
+  recursive subroutine mergesort_rows(A,i,j,buffer)
+    implicit none
+    integer :: i,j,L,mid,i0,j0,k,k2,pos,buffer(0:,:),A(0:,:)
+    logical :: aux_bool
+    L = j-i+1
+    if (L>1) then
+      if (L==2) then
+        if (is_greater(A(i,:),A(j,:))) then
+          buffer(0,:) = A(i,:)
+          A(i,:)      = A(j,:)
+          A(j,:)      = buffer(0,:)
+        end if
+      else
+        mid = (i+j)/2
+        call mergesort_rows(A,     i, mid, buffer)
+        call mergesort_rows(A, mid+1,   j, buffer)
+        i0 = i
+        j0 = mid+1
+        k  = 0
+        do while (((i0<=mid).or.(j0<=j)).and.(k<=L))
+          aux_bool = (j0>j)
+          if (.not.aux_bool) then
+            aux_bool = (i0<=mid)
+            if (aux_bool) aux_bool=aux_bool.and.(.not.is_greater(A(i0,:),A(j0,:)))
+          end if
+          if (aux_bool) then !((j0>j).or.((i0<=mid).and.(.not.is_greater(A(i0,:),A(j0,:))))) then
+            buffer(k,:) = A(i0,:)
+            i0          = i0 + 1
+          else
+            buffer(k,:) = A(j0,:)
+            j0          = j0 + 1
+          end if
+          k = k + 1
+        end do
+        pos = i
+        do k2=0,k-1
+          A(pos,:) = buffer(k2,:)
+          pos      = pos + 1
+        end do
+      end if
+    end if
+  end subroutine
+
+  ! ---------------------- autotuning summaries ----------------------
+  subroutine diezdecomp_summary_transp_autotuning(this)
+    implicit none
+    type(diezdecomp_props_transp) :: this
+    integer                       :: pos, use_alltoallv, use_isendirecv, use_nccl, temp_count
+    character(len=65)             :: txt
+    character(len=84)             :: stats84
+    associate(irank => this%irank, nproc => this%nproc)
+      if (irank==0) write(*,'(A57)') '------------------- Summary Transpose -------------------'
+
+      call check_unique_int(this%chosen_reorder(0))
+      call check_unique_int(this%chosen_reorder(1))
+      call check_unique_int(this%chosen_reorder(2))
+      if (irank==0) write(*,'(A26,3I2)')            '    Loop order chosen  :  ', this%chosen_reorder
+      do pos=0,5
+        call get_stats_value(txt, this%elapsed_time_reorder(pos))
+        if (irank==0) write(*,'(A26,3I2,A2,A65)') '    Elapsed time, order: (', this%reorder_ijk(:,pos),') ', txt
+      end do
+
+      use_alltoallv   =  0
+      use_isendirecv  =  0
+      use_nccl        =  0
+      if (this%use_alltoallv  ) use_alltoallv   =  1
+      if (this%use_isendirecv ) use_isendirecv  =  1
+      if (this%use_nccl       ) use_nccl        =  1
+
+      call check_unique_int(use_alltoallv)
+      call check_unique_int(use_isendirecv)
+      call check_unique_int(use_nccl)
+
+      if (this%single_device) then
+        if (irank==0)                       write(*,'(A47)') '    MPI mode chosen      : None (single_device)'
+      else
+        if ((use_alltoallv+use_isendirecv+use_nccl) /= 1) error stop 'ERROR: (use_alltoallv+use_isendirecv+use_nccl) /= 1)'
+        if (this%use_alltoallv .and.(irank==0))  write(*,'(A38)') '    MPI mode chosen      : AlltoAllV  '
+        if (this%use_isendirecv.and.(irank==0))  write(*,'(A38)') '    MPI mode chosen      : ISend/IRecv'
+        if (this%use_nccl      .and.(irank==0))  write(*,'(A38)') '    MPI mode chosen      : NCCL       '
+      end if
+
+      call get_stats_value(txt, this%elapsed_alltoallv)
+      if (irank==0) write(*,'(A45,A65)') '    Elapsed time       : AlltoAllV (sync)    ', txt
+
+      call get_stats_value(txt, this%elapsed_isendirecv)
+      if (irank==0) write(*,'(A45,A65)') '    Elapsed time       : ISend/IRecv (async) ', txt
+
+      call get_stats_value(txt, this%elapsed_nccl)
+      if (irank==0) write(*,'(A45,A65)') '    Elapsed time       : NCCL        (async) ', txt
+
+      if (irank==0) write(*,*) ''
+
+      call get_count_int(temp_count, this%send_autotuned, 1)
+      call get_stats_modes(stats84, this%send_mode_op_simul)
+      if (irank==0) write(*,'(A48,I6,A84)')         '    Transpose mode Simultaneous chosen (send) : ',temp_count,stats84
+      call get_stats_value(txt, this%send_elapsed_simul_top)
+      if (irank==0) write(*,'(A45,A65)')            '    Elapsed time: Simultaneous (send) (best) ', txt
+      if (irank==0) write(*,*) ''
+      do pos=0,5
+        call get_stats_value(txt, this%send_elapsed_simul_modes(pos))
+        if (irank==0) write(*,'(A45,I2,A2,A65)')    '    Elapsed time, Simultaneous (send) (mode: ', pos+1,') ', txt
+      end do
+      if (irank==0) write(*,*) ''
+
+      call get_count_int(temp_count, this%send_autotuned, 2)
+      call get_stats_modes(stats84, this%send_mode_op_batched)
+      if (irank==0) write(*,'(A48,I6,A84)')         '    Transpose mode Batched      chosen (send) : ',temp_count,stats84
+      call get_stats_value(txt, this%send_elapsed_batched_top)
+      if (irank==0) write(*,'(A45,A65)')            '    Elapsed time: Batched      (send) (best) ', txt
+      if (irank==0) write(*,*) ''
+      do pos=0,5
+        call get_stats_value(txt, this%send_elapsed_batched_modes(pos))
+        if (irank==0) write(*,'(A45,I2,A2,A65)')    '    Elapsed time, Batched      (send) (mode: ', pos+1,') ', txt
+      end do
+      if (irank==0) write(*,*) ''
+
+      call get_count_int(temp_count, this%recv_autotuned, 1)
+      call get_stats_modes(stats84, this%recv_mode_op_simul)
+      if (irank==0) write(*,'(A48,I6,A84)')         '    Transpose mode Simultaneous chosen (recv) : ',temp_count,stats84
+      call get_stats_value(txt, this%recv_elapsed_simul_top)
+      if (irank==0) write(*,'(A45,A65)')            '    Elapsed time: Simultaneous (recv) (best) ', txt
+      if (irank==0) write(*,*) ''
+      do pos=0,5
+        call get_stats_value(txt, this%recv_elapsed_simul_modes(pos))
+        if (irank==0) write(*,'(A45,I2,A2,A65)')    '    Elapsed time, Simultaneous (recv) (mode: ', pos+1,') ', txt
+      end do
+      if (irank==0) write(*,*) ''
+
+      call get_count_int(temp_count, this%recv_autotuned, 2)
+      call get_stats_modes(stats84, this%recv_mode_op_batched)
+      if (irank==0) write(*,'(A48,I6,A84)')         '    Transpose mode Batched      chosen (recv) : ',temp_count,stats84
+      call get_stats_value(txt, this%recv_elapsed_batched_top)
+      if (irank==0) write(*,'(A45,A65)')            '    Elapsed time: Batched      (recv) (best) ', txt
+      if (irank==0) write(*,*) ''
+      do pos=0,5
+        call get_stats_value(txt, this%recv_elapsed_batched_modes(pos))
+        if (irank==0) write(*,'(A45,I2,A2,A65)')    '    Elapsed time, Batched      (recv) (mode: ', pos+1,') ', txt
+      end do
+      if (irank==0) write(*,*) ''
+    end associate
+  end subroutine
+
+  subroutine get_stats_modes(txt,val)
+    character(len=84) :: txt
+    integer           :: val, i, p(1:6), other, temp_int, mpi_ierr
+    p     = 0
+    other = 0
+    if ((val<1).or.(6<val)) then
+      other = other + 1
+    else
+        p(val) = p(val) + 1
+    end if
+    do i=1,6
+      temp_int = p(i)
+      call MPI_Allreduce(temp_int , p(i), 1, mpi_int, mpi_sum, mpi_comm_world, mpi_ierr)
+    end do
+    write(txt,'(A5,I6,A6,I6,A6,I6,A6,I6,A6,I6,A6,I6,A6,I6,A1)') ' (1: ',p(1),' , 2: ',p(2),' , 3: ',p(3),&
+                                                               ' , 4: ',p(4),' , 5: ',p(5),' , 6: ',p(6),' , ?: ',other,')'
+  end subroutine
+
+  subroutine diezdecomp_summary_halo_autotuning(this)
+    implicit none
+    type(diezdecomp_props_halo) :: this
+    character(len=65)           :: txt
+    associate(irank => this%irank, nproc => this%nproc, nh_dir => this%nh_dir)
+      if (irank==0) write(*,*) ''
+      if (irank==0) write(*,'(A57)') '-------------------- Halo Autotuning --------------------'
+
+      call check_unique_int(this%halo_mpi_mode)
+
+      if (this%halo_mpi_mode==1) then
+        if (irank==0) write(*,'(A44)')   '    MPI mode chosen    : MPI_SendRecv (sync)'
+      else if (this%halo_mpi_mode==2) then
+        if (irank==0) write(*,'(A44)')   '    MPI mode chosen    : ISend/IRecv (async)'
+      else
+        if (.not.((nproc== 1).or.(nh_dir==0))) error stop 'ERROR: this%halo_mpi_mode out-of-range'
+        if (irank==0)   write(*,'(A37,I6,A10,I6,A1)') '    MPI mode chosen    : None (nproc=',nproc,') (nh_dir=',nh_dir,')'
+      end if
+      if (irank==0) write(*,*) ''
+      call get_stats_value(txt, this%elapsed_sendrecv)
+      if (irank==0) write(*,'(A45,A65)') '    Elapsed time       : MPI_SendRecv (sync) ', txt
+      call get_stats_value(txt, this%elapsed_isendirecv)
+      if (irank==0) write(*,'(A45,A65)') '    Elapsed time       : ISend/IRecv (async) ', txt
+      if (irank==0) write(*,*) ''
+      call check_unique_int(this%autotuned_pack)
+
+      if (this%autotuned_pack==2) then
+        if (irank==0) write(*,'(A40)')    '    Packing mode chosen: pack_slices_2d '
+      else if (this%autotuned_pack==3) then
+        if (irank==0) write(*,'(A40)')    '    Packing mode chosen: pack_slices_3d '
+      else
+        if (nh_dir == 0) then
+          if (irank==0) write(*,'(A40)')  '    Packing mode chosen: None (nh_dir=0)'
+        else
+          error stop 'ERROR: this%autotuned_pack out-of-range'
+        end if
+      end if
+      if (irank==0) write(*,*) ''
+      call get_stats_value(txt, this%wtime_2)
+      if (irank==0) write(*,'(A45,A65)') '    Elapsed time       : pack_slices_2d      ', txt
+      call get_stats_value(txt, this%wtime_3)
+      if (irank==0) write(*,'(A45,A65)') '    Elapsed time       : pack_slices_3d      ', txt
+      if (irank==0) write(*,*) ''
+    end associate
+  end subroutine
+
+  subroutine check_unique_int(val)
+    integer :: val, mpi_ierr, val_min, val_max
+    call MPI_Allreduce(val, val_min, 1, mpi_int, mpi_min, mpi_comm_world, mpi_ierr)
+    call MPI_Allreduce(val, val_max, 1, mpi_int, mpi_max, mpi_comm_world, mpi_ierr)
+    if (val_min /= val_max) error stop 'ERROR: check_unique_int (val_min /= val_max)'
+  end subroutine
+
+  subroutine get_stats_value(txt, val)
+    real(rp)          ::  val, val_min, val_max, val_avg
+    integer           ::  mpi_ierr, total, int1
+    character(len=65) :: txt
+    int1 = 1
+    call MPI_Allreduce(val , val_min, 1, MPI_REAL_RP, mpi_min, mpi_comm_world, mpi_ierr)
+    call MPI_Allreduce(val , val_max, 1, MPI_REAL_RP, mpi_max, mpi_comm_world, mpi_ierr)
+    call MPI_Allreduce(val , val_avg, 1, MPI_REAL_RP, mpi_sum, mpi_comm_world, mpi_ierr)
+    call MPI_Allreduce(int1, total  , 1, mpi_int    , mpi_sum, mpi_comm_world, mpi_ierr)
+    val_avg  =  val_avg / (total+0.d0)
+    write(txt,'(A6,E14.6,A8,E14.6,A8,E14.6,A1)') '(min: ',val_min,' , avg: ',val_avg,' , max: ',val_max,')'
+  end subroutine
+
+  subroutine get_count_int(n, val, target_val)
+    integer :: n,val,target_val,temp_int, mpi_ierr
+    temp_int = 0
+    n        = 0
+    if (val==target_val) temp_int = 1
+    call MPI_Allreduce(temp_int, n, 1, mpi_int, mpi_sum, mpi_comm_world, mpi_ierr)
+  end subroutine
+
+  subroutine check_a2av_alignment(my_ids, n, ii, jj, kk, k0, k1, s, order, all_lo, all_hi, use_alltoallv, irank, jj_pos)
+    integer :: i_loc, j_loc, k_loc, j_prev, n, ii, jj, kk, k0, k1, other, &
+               s(0:2), order(0:2), all_lo(0:,0:), all_hi(0:,0:), my_ids(0:), pos, irank, jj_pos
+    logical :: use_alltoallv
+    i_loc   =  diezdecomp_get_index_int2int(order, ii)
+    j_loc   =  diezdecomp_get_index_int2int(order, jj)
+    k_loc   =  diezdecomp_get_index_int2int(order, kk)
+    j_prev  =  -1
+    if (use_alltoallv) then
+      do pos=0,n
+        other = my_ids(pos)
+        if      (all_lo(i_loc,other) /= 0             ) use_alltoallv = .false.
+        if      (all_hi(i_loc,other) /= (s(i_loc)-1)  ) use_alltoallv = .false.
+        if      (all_lo(j_loc,other)<=j_prev          ) use_alltoallv = .false.
+        j_prev = all_hi(j_loc,other)
+        if (k0<0) k0 = all_lo(k_loc,other)
+        if (k1<0) k1 = all_hi(k_loc,other)
+        if (all_lo(k_loc,other) /= k0            ) use_alltoallv = .false.
+        if (all_hi(k_loc,other) /= k1            ) use_alltoallv = .false.
+        if (other == irank) jj_pos = j_prev
+      end do
+    end if
+  end subroutine
+end module

--- a/dependencies/external.mk
+++ b/dependencies/external.mk
@@ -2,12 +2,21 @@
 # external libraries compilation
 #
 ifeq ($(strip $(GPU)),1)
+ifneq ($(strip $(USE_DIEZDECOMP)),1)
 libs: $(wildcard $(LIBS_DIR)/2decomp-fft/src/*.f90)
 	cd $(LIBS_DIR)/2decomp-fft && make
 	cd $(LIBS_DIR)/cuDecomp && mkdir -p build && cd build && cmake .. && make -j
 libsclean: $(wildcard $(LIBS_DIR)/2decomp-fft/src/*.f90)
 	cd $(LIBS_DIR)/2decomp-fft && make clean
 	cd $(LIBS_DIR)/cuDecomp/build && make clean; cd .. && rm -rf build
+else
+libs: $(wildcard $(LIBS_DIR)/2decomp-fft/src/*.f90)
+	cd $(LIBS_DIR)/2decomp-fft && make
+	cd $(LIBS_DIR)/diezDecomp && make -j
+libsclean: $(wildcard $(LIBS_DIR)/2decomp-fft/src/*.f90)
+	cd $(LIBS_DIR)/2decomp-fft && make clean
+	cd $(LIBS_DIR)/diezDecomp && make clean
+endif
 else
 libs: $(wildcard $(LIBS_DIR)/2decomp-fft/src/*.f90)
 	cd $(LIBS_DIR)/2decomp-fft && make

--- a/docs/INFO_COMPILING.md
+++ b/docs/INFO_COMPILING.md
@@ -23,9 +23,10 @@ GPU=0              # GPU build
 In this file, `FCOMP` can be one of `GNU` (`gfortran`), `INTEL` (`ifort`), `NVIDIA` (`nvfortran`), or `CRAY` (`ftn`); the predefined profiles for compiler options can be selected by choosing one of the `FFLAGS_*` option; finer control of the compiler flags may be achieved by building with, e.g., `make FFLAGS+=[OTHER_FLAGS]`, or by tweaking the profiles directly under `configs/flags.mk`. Similarly, the library paths (e.g., for *FFTW*) may need to be adapted in the `Makefile` (`LIBS` variable) or by building with `make LIBS+='-L[PATH_TO_LIB] -l[NAME_OF_LIB]'`. Finally, the following pre-processing options are available:
 
  * `SINGLE_PRECISION` : calculation will be carried out in single precision (the default precision is double)
- * `GPU`              : enable GPU accelerated runs (requires the `FCOMP=NVIDIA`)
+ * `GPU`              : enable GPU accelerated runs
+ * `USE_DIEZDECOMP`   : use [diezDecomp](https://github.com/Rafael10Diez/diezDecomp) as GPU communication backend instead of the default (cuDecomp), e.g., for portability in different accelerators. While diezDecomp supports CPU-CPU communication, this is not used in CaNS yet.
 
-Typing `make libs` will build the 2DECOMP&FFT/cuDecomp libraries; then typing `make` will compile the code and copy the executable `cans` to a `run/` folder; `make run` will also copy the default input files `*.in` under `src/` to the same `run/` folder.
+Typing `make libs` will build the 2DECOMP&FFT/cuDecomp/diezDecomp libraries; then typing `make` will compile the code and copy the executable `cans` to a `run/` folder; `make run` will also copy the default input files `*.in` under `src/` to the same `run/` folder.
 
 Note that cuDecomp needs to be dynamically linked before performing a GPU run. To do this, one should update the `LD_LIBRARY_PATH` environment variable as follows (from the root directory):
 ```shell

--- a/src/bound.f90
+++ b/src/bound.f90
@@ -594,17 +594,23 @@ module mod_bound
 #if defined(_OPENACC)
   subroutine updthalo_gpu(nh,periods,p)
     use mod_types
+#if !defined(_USE_DIEZDECOMP)
     use cudecomp
+#else
+    use diezdecomp
+#endif
     use mod_common_cudecomp, only: work => work_halo, &
                                    ch => handle,gd => gd_halo, &
                                    dtype => cudecomp_real_rp, &
-                                   istream => istream_acc_queue_1
+                                   istream => istream_acc_queue_1_comm_lib
     implicit none
     integer , intent(in) :: nh
     logical , intent(in) :: periods(3)
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
     integer :: istat
+#if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(p,work)
+#endif
     select case(ipencil_axis)
     case(1)
       istat = cudecompUpdateHalosX(ch,gd,p,work,dtype,[nh,nh,nh],periods,2,stream=istream)
@@ -616,7 +622,9 @@ module mod_bound
       istat = cudecompUpdateHalosZ(ch,gd,p,work,dtype,[nh,nh,nh],periods,1,stream=istream)
       istat = cudecompUpdateHalosZ(ch,gd,p,work,dtype,[nh,nh,nh],periods,2,stream=istream)
     end select
+#if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
+#endif
   end subroutine updthalo_gpu
 #endif
 end module mod_bound

--- a/src/common_cudecomp.f90
+++ b/src/common_cudecomp.f90
@@ -8,7 +8,11 @@ module mod_common_cudecomp
 #if defined(_OPENACC)
   use mod_types
   !@cuf use cudafor
+#if !defined(_USE_DIEZDECOMP)
   use cudecomp
+#else
+  use diezdecomp
+#endif
   use openacc
   use mod_param, only: cudecomp_is_t_in_place
   implicit none
@@ -30,6 +34,6 @@ module mod_common_cudecomp
   !@cuf attributes(device) :: work_halo_cuda,work_ptdma_cuda
   real(rp), target, allocatable, dimension(:) :: solver_buf_0,solver_buf_1
   real(rp), allocatable, dimension(:,:,:) :: pz_aux_1,pz_aux_2
-  integer(acc_handle_kind) :: istream_acc_queue_1
+  integer(acc_handle_kind) :: istream_acc_queue_1,istream_acc_queue_1_comm_lib
 #endif
 end module mod_common_cudecomp

--- a/src/common_cudecomp.f90
+++ b/src/common_cudecomp.f90
@@ -25,8 +25,8 @@ module mod_common_cudecomp
   integer(i8) :: wsize_fft
   real(rp), pointer, contiguous, dimension(:) :: work     ,work_cuda
   real(rp), pointer, contiguous, dimension(:) :: work_halo,work_halo_cuda
-  !@cuf attributes(device) :: work_cuda,work_halo_cuda
   real(rp), pointer, contiguous, dimension(:) :: work_ptdma,work_ptdma_cuda
+  !@cuf attributes(device) :: work_cuda,work_halo_cuda
   !@cuf attributes(device) :: work_halo_cuda,work_ptdma_cuda
   real(rp), target, allocatable, dimension(:) :: solver_buf_0,solver_buf_1
   real(rp), allocatable, dimension(:,:,:) :: pz_aux_1,pz_aux_2

--- a/src/diesdecomp.f90
+++ b/src/diesdecomp.f90
@@ -1,0 +1,51 @@
+! -
+!
+! SPDX-FileCopyrightText: Copyright (c) 2017-2022 Pedro Costa and the CaNS contributors. All rights reserved.
+! SPDX-License-Identifier: MIT
+!
+! -
+module diezdecomp
+#if defined(_OPENACC) && defined(_USE_DIEZDECOMP)
+  !
+  ! named constants
+  !
+  use diezdecomp_api_cans, only: CUDECOMP_RANK_NULL => diezdecomp_rank_null
+  !
+  ! types
+  !
+  use diezdecomp_api_cans, only: cudecompHandle     => diezdecompHandle, &
+                                 cudecompGridDesc   => diezdecompGridDesc, &
+                                 cudecompPencilInfo => diezdecompPencilInfo
+  !
+  ! initialization functions
+  !
+  use diezdecomp_api_cans, only: diezdecompGridDescCreate
+  !
+  ! query functions - pencils and decomposition
+  !
+  use diezdecomp_api_cans, only: cudecompGetPencilInfo  => diezdecompGetPencilInfo, &
+                                 cudecompGetShiftedRank => diezdecompGetShiftedRank
+  !
+  ! query functions - workspace sizes
+  !
+  use diezdecomp_api_cans, only: cudecompGetTransposeWorkspaceSize => diezdecomp_get_workspace_size_transposes, &
+                                 cudecompGetHaloWorkspaceSize      => diezdecomp_get_workspace_size_halos
+  !
+  ! collective transposes functions
+  !
+  use diezdecomp_api_cans, only: cudecompTransposeXtoY => diezdecompTransposeXtoY, &
+                                 cudecompTransposeYtoX => diezdecompTransposeYtoX, &
+                                 cudecompTransposeYtoZ => diezdecompTransposeYtoZ, &
+                                 cudecompTransposeZtoY => diezdecompTransposeZtoY, &
+                                                          diezdecompTransposeXtoZ, &
+                                                          diezdecompTransposeZtoX
+  !
+  ! halo update functions
+  !
+  use diezdecomp_api_cans, only: cudecompUpdateHalosX => diezdecompUpdateHalosX, &
+                                 cudecompUpdateHalosY => diezdecompUpdateHalosY, &
+                                 cudecompUpdateHalosZ => diezdecompUpdateHalosZ
+  implicit none
+  public
+#endif
+end module diezdecomp

--- a/src/fftw.f90
+++ b/src/fftw.f90
@@ -7,7 +7,28 @@
 module mod_fftw_param
   use, intrinsic :: iso_c_binding
 #if defined(_OPENACC)
+#if !defined(_USE_HIP)
   use cufft
+#else
+  use hipfort_hipfft, only: CUFFT_R2C => HIPFFT_R2C, &
+                            CUFFT_C2R => HIPFFT_C2R, &
+                            CUFFT_D2Z => HIPFFT_D2Z, &
+                            CUFFT_Z2D => HIPFFT_Z2D, &
+                            cufftSetWorkArea       => hipfftSetWorkArea_, &
+                            cufftSetStream         => hipfftSetStream_, &
+                            cufftCreate            => hipfftCreate_, &
+                            cufftSetAutoAllocation => hipfftSetAutoAllocation_, &
+                            cufftMakePlanMany      => hipfftMakePlanMany_, &
+                            cufftDestroy           => hipfftDestroy_, &
+#if defined(_SINGLE_PRECISION)
+                            cufftExecR2C => hipfftExecR2C_, &
+                            cufftExecC2R => hipfftExecC2R_
+#else
+                            cufftExecD2Z => hipfftExecD2Z_, &
+                            cufftExecZ2D => hipfftExecZ2D_
+#endif
+  use hipfort       , only: hipDeviceSynchronize
+#endif
 #endif
   implicit none
   !

--- a/src/initsolver.f90
+++ b/src/initsolver.f90
@@ -26,7 +26,7 @@ module mod_initsolver
     real(rp), intent(out), dimension(lo_z(1):,lo_z(2):) :: lambdaxy
     character(len=1), intent(in), dimension(3) :: c_or_f
     real(rp), intent(out), dimension(lo_z(3):) :: a,b,c
-#if !defined(_OPENACC)
+#if !defined(_OPENACC) || defined(_USE_HIP)
     type(C_PTR), intent(out), dimension(2,2) :: arrplan
 #else
     integer    , intent(out), dimension(2,2) :: arrplan

--- a/src/main.f90
+++ b/src/main.f90
@@ -90,7 +90,7 @@ program cans
   real(rp), allocatable, dimension(:,:,:) :: dudtrko,dvdtrko,dwdtrko
   real(rp), dimension(0:1,3) :: tauxo,tauyo,tauzo
   real(rp), dimension(3) :: f
-#if !defined(_OPENACC)
+#if !defined(_OPENACC) || defined(_USE_HIP)
   type(C_PTR), dimension(2,2) :: arrplanp
 #else
   integer    , dimension(2,2) :: arrplanp
@@ -103,7 +103,7 @@ program cans
   real(rp) :: normfftp
   type(rhs_bound) :: rhsbp
   real(rp) :: alpha
-#if !defined(_OPENACC)
+#if !defined(_OPENACC) || defined(_USE_HIP)
   type(C_PTR), dimension(2,2) :: arrplanu,arrplanv,arrplanw
 #else
   integer    , dimension(2,2) :: arrplanu,arrplanv,arrplanw

--- a/src/param.f90
+++ b/src/param.f90
@@ -6,7 +6,7 @@
 ! -
 module mod_param
 use mod_types
-#if defined(_OPENACC)
+#if defined(_OPENACC) && !defined(_USE_DIEZDECOMP)
 use cudecomp
 #endif
 implicit none
@@ -87,6 +87,7 @@ logical, protected :: cudecomp_is_t_comm_autotune ,cudecomp_is_h_comm_autotune ,
                       cudecomp_is_t_enable_nccl   ,cudecomp_is_h_enable_nccl   , &
                       cudecomp_is_t_enable_nvshmem,cudecomp_is_h_enable_nvshmem, &
                       cudecomp_is_t_in_place
+logical, protected :: is_use_diezdecomp = .false.,is_diezdecomp_x2z_z2x_transposes = .false.
 #endif
 !
 ! other options: debugging/benchmarking
@@ -129,7 +130,7 @@ contains
                   gacc, &
                   nscal, &
                   dims,ipencil_axis
-#if defined(_OPENACC)
+#if defined(_OPENACC) && !defined(_USE_DIEZDECOMP)
     namelist /cudecomp/ &
                        cudecomp_t_comm_backend,cudecomp_is_t_enable_nccl,cudecomp_is_t_enable_nvshmem, &
                        cudecomp_h_comm_backend,cudecomp_is_h_enable_nccl,cudecomp_is_h_enable_nvshmem
@@ -182,6 +183,7 @@ contains
         if(myid == 0) print*, 'Defaulting to `ipencil_axis = 1` (x-aligned pencils)...'
       end if
 #if defined(_OPENACC)
+#if !defined(_USE_DIEZDECOMP)
       !
       ! reading cuDecomp parameters, if these are set
       !
@@ -245,6 +247,10 @@ contains
       ! manually set cuDecomp out-of-place transposes by default
       !
       cudecomp_is_t_in_place = .false.
+#else
+      is_use_diezdecomp = .true.
+      is_diezdecomp_x2z_z2x_transposes = .false.
+#endif
 #endif
       !
       ! reading scalar transport parameters, if these are set

--- a/src/scal.f90
+++ b/src/scal.f90
@@ -26,7 +26,7 @@ module mod_scal
     real(rp) :: scalf
     real(rp) :: f
     real(rp), dimension(0:1,3) :: fluxo
-#if !defined(_OPENACC)
+#if !defined(_OPENACC) || defined(_USE_HIP)
     type(C_PTR), dimension(2,2) :: arrplan
 #else
     integer    , dimension(2,2) :: arrplan

--- a/src/solve_helmholtz.f90
+++ b/src/solve_helmholtz.f90
@@ -30,7 +30,7 @@ module mod_solve_helmholtz
     ! this is a wrapper subroutine to solve 1D/3D helmholtz problems: p/alpha + lap(p) = rhs
     !
     integer ,    intent(in   ), dimension(3)                :: n,ng,hi
-#if !defined(_OPENACC)
+#if !defined(_OPENACC) || defined(_USE_HIP)
     type(C_PTR), intent(in   ), dimension(2,2),    optional :: arrplan
 #else
     integer    , intent(in   ), dimension(2,2),    optional :: arrplan

--- a/src/solver_gpu.f90
+++ b/src/solver_gpu.f90
@@ -29,7 +29,11 @@ module mod_solver_gpu
   subroutine solver_gpu(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_ptdma_update,aa_z,cc_z)
     implicit none
     integer , intent(in), dimension(3) :: n,ng
-    integer , intent(in), dimension(2,2) :: arrplan
+#if !defined(_USE_HIP)
+    integer    , intent(in), dimension(2,2) :: arrplan
+#else
+    type(C_PTR), intent(in), dimension(2,2) :: arrplan
+#endif
     real(rp), intent(in) :: normfft
     real(rp), intent(in), dimension(:,:) :: lambdaxy
     real(rp), intent(in), dimension(:) :: a,b,c

--- a/src/solver_gpu.f90
+++ b/src/solver_gpu.f90
@@ -7,7 +7,11 @@
 module mod_solver_gpu
 #if defined(_OPENACC)
   use, intrinsic :: iso_c_binding, only: C_PTR
+#if !defined(_USE_DIEZDECOMP)
   use cudecomp
+#else
+  use diezdecomp
+#endif
   use mod_common_cudecomp, only: dtype_rp => cudecomp_real_rp, &
                                  cudecomp_is_t_in_place, &
                                  solver_buf_0,solver_buf_1, &
@@ -18,9 +22,10 @@ module mod_solver_gpu
                                  ap_x_0 => ap_x    , &
                                  ap_z_0 => ap_z    , &
                                  ch => handle,gd => gd_poi, gd_io => gd_poi_io, &
-                                 istream => istream_acc_queue_1
+                                 istream => istream_acc_queue_1_comm_lib
   use mod_fft            , only: signal_processing,fftf_gpu,fftb_gpu
-  use mod_param          , only: ipencil_axis,is_poisson_pcr_tdma
+  use mod_param          , only: ipencil_axis,is_poisson_pcr_tdma, &
+                                 is_use_diezdecomp,is_diezdecomp_x2z_z2x_transposes
   use mod_types
   implicit none
   private
@@ -87,34 +92,61 @@ module mod_solver_gpu
     case(2)
       ap_io = ap_x_0
       pad_io(:) = ap_x%shape(:) - ap_io%shape(:)
+#if !defined(_USE_DIEZDECOMP)
       !$acc host_data use_device(p,px,work)
+#endif
       istat = cudecompTransposeYtoX(ch,gd_io,p ,px,work,dtype_rp,input_halo_extents  = [1,1,1], &
                                                                  output_halo_extents = [0,0,0], &
                                                                  input_padding       = [0,0,0], &
                                                                  output_padding      = pad_io, &
                                                                  stream=istream)
+#if !defined(_USE_DIEZDECOMP)
       !$acc end host_data
+#endif
     case(3)
-      istat = cudecompGetPencilInfo(ch,gd_io,ap_io,2) ! mem_order = [2,3,1]
-      pad_io(:) = ap_y%shape(:) - ap_io%shape(:)
-      pad_io(ap_y%order(:)) = pad_io(:)
-      !$acc host_data use_device(p,py,px,work)
-      istat = cudecompTransposeZtoY(ch,gd_io,p ,py,work,dtype_rp,input_halo_extents  = [1,1,1], &
-                                                                 output_halo_extents = [0,0,0], &
-                                                                 input_padding       = [0,0,0], &
-                                                                 output_padding      = pad_io, &
-                                                                 stream=istream)
-      istat = cudecompTransposeYtoX(ch,gd   ,py,px,work,dtype_rp,stream=istream)
+      if(.not.is_diezdecomp_x2z_z2x_transposes) then
+        istat = cudecompGetPencilInfo(ch,gd_io,ap_io,2) ! mem_order = [2,3,1]
+        pad_io(:) = ap_y%shape(:) - ap_io%shape(:)
+#if !defined(_USE_DIEZDECOMP)
+        pad_io(ap_y%order(:)) = pad_io(:)
+        !$acc host_data use_device(p,py,px,work)
+#endif
+        istat = cudecompTransposeZtoY(ch,gd_io,p ,py,work,dtype_rp,input_halo_extents  = [1,1,1], &
+                                                                   output_halo_extents = [0,0,0], &
+                                                                   input_padding       = [0,0,0], &
+                                                                   output_padding      = pad_io, &
+                                                                   stream=istream)
+        istat = cudecompTransposeYtoX(ch,gd   ,py,px,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
       !$acc end host_data
+#endif
+      else
+#if defined(_USE_DIEZDECOMP)
+        !$acc parallel loop collapse(3) default(present) async(1)
+        !$OMP parallel do   collapse(3) DEFAULT(shared)
+        do k=1,n(3)
+          do j=1,n(2)
+            do i=1,n(1)
+              pz(i,j,k) = p(i,j,k)
+            end do
+          end do
+        end do
+        istat = diezdecompTransposeZtoX(ch,gd,pz,px,work,dtype_rp,stream=istream)
+#endif
+      end if
     end select
     !
     call signal_processing(0,'F',bc(0,1)//bc(1,1),c_or_f(1),ng(1),n_x,1,px)
     call fftf_gpu(arrplan(1,1),px)
     call signal_processing(1,'F',bc(0,1)//bc(1,1),c_or_f(1),ng(1),n_x,1,px)
     !
+#if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(px,py,work)
+#endif
     istat = cudecompTransposeXtoY(ch,gd,px,py,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
+#endif
     !
     call signal_processing(0,'F',bc(0,2)//bc(1,2),c_or_f(2),ng(2),n_y,1,py)
     call fftf_gpu(arrplan(1,2),py)
@@ -123,15 +155,23 @@ module mod_solver_gpu
     q = merge(1,0,c_or_f(3) == 'f'.and.bc(1,3) == 'D'.and.hi_z_0(3) == ng(3))
     is_periodic_z = bc(0,3)//bc(1,3) == 'PP'
     if(.not.is_poisson_pcr_tdma) then
+#if !defined(_USE_DIEZDECOMP)
       !$acc host_data use_device(py,pz,work)
+#endif
       istat = cudecompTransposeYtoZ(ch,gd,py,pz,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
       !$acc end host_data
+#endif
       !
       call gaussel_gpu(n_z_0(1),n_z_0(2),n_z_0(3)-q,0,a,b,c,is_periodic_z,norm,pz,work,pz_aux_1,lambdaxy)
       !
+#if !defined(_USE_DIEZDECOMP)
       !$acc host_data use_device(pz,py,work)
+#endif
       istat = cudecompTransposeZtoY(ch,gd,pz,py,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
       !$acc end host_data
+#endif
     else
       block
         use mod_common_cudecomp, only: ap_y
@@ -181,9 +221,13 @@ module mod_solver_gpu
     call fftb_gpu(arrplan(2,2),py)
     call signal_processing(1,'B',bc(0,2)//bc(1,2),c_or_f(2),ng(2),n_y,1,py)
     !
+#if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(py,px,work)
+#endif
     istat = cudecompTransposeYtoX(ch,gd,py,px,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
+#endif
     !
     call signal_processing(0,'B',bc(0,1)//bc(1,1),c_or_f(1),ng(1),n_x,1,px)
     call fftb_gpu(arrplan(2,1),px)
@@ -201,22 +245,45 @@ module mod_solver_gpu
         end do
       end do
     case(2)
+#if !defined(_USE_DIEZDECOMP)
       !$acc host_data use_device(px,p,work)
+#endif
       istat = cudecompTransposeXtoY(ch,gd_io,px,p ,work,dtype_rp,input_halo_extents  = [0,0,0], &
                                                                  output_halo_extents = [1,1,1], &
                                                                  input_padding       = pad_io, &
                                                                  output_padding      = [0,0,0], &
                                                                  stream=istream)
+#if !defined(_USE_DIEZDECOMP)
       !$acc end host_data
+#endif
     case(3)
-      !$acc host_data use_device(px,py,p,work)
-      istat = cudecompTransposeXtoY(ch,gd   ,px,py,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_io,py,p ,work,dtype_rp,input_halo_extents  = [0,0,0], &
-                                                                 output_halo_extents = [1,1,1], &
-                                                                 input_padding       = pad_io, &
-                                                                 output_padding      = [0,0,0], &
-                                                                 stream=istream)
+      if(.not.is_diezdecomp_x2z_z2x_transposes) then
+#if !defined(_USE_DIEZDECOMP)
+        !$acc host_data use_device(px,py,p,work)
+#endif
+        istat = cudecompTransposeXtoY(ch,gd   ,px,py,work,dtype_rp,stream=istream)
+        istat = cudecompTransposeYtoZ(ch,gd_io,py,p ,work,dtype_rp,input_halo_extents  = [0,0,0], &
+                                                                   output_halo_extents = [1,1,1], &
+                                                                   input_padding       = pad_io, &
+                                                                   output_padding      = [0,0,0], &
+                                                                   stream=istream)
+#if !defined(_USE_DIEZDECOMP)
       !$acc end host_data
+#endif
+      else
+#if defined(_USE_DIEZDECOMP)
+        istat = diezdecompTransposeXtoZ(ch,gd,px,pz,work,dtype_rp,stream=istream)
+        !$acc parallel loop collapse(3) default(present) async(1)
+        !$OMP parallel do   collapse(3) DEFAULT(shared)
+        do k=1,n(3)
+          do j=1,n(2)
+            do i=1,n(1)
+              p(i,j,k) = pz(i,j,k)
+            end do
+          end do
+        end do
+#endif
+      end if
     end select
   end subroutine solver_gpu
   !
@@ -508,10 +575,14 @@ module mod_solver_gpu
     if(present(is_update) .and. present(aa_z_save) .and. present(cc_z_save)) then
       if(is_update) then
         is_update = .false.
+#if !defined(_USE_DIEZDECOMP)
         !$acc host_data use_device(aa_y,cc_y,aa_z_save,cc_z_save,work)
+#endif
         istat = cudecompTransposeYtoZ(ch,gd_ptdma,aa_y,aa_z_save,work,dtype_rp,stream=istream)
         istat = cudecompTransposeYtoZ(ch,gd_ptdma,cc_y,cc_z_save,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
         !$acc end host_data
+#endif
       end if
       !$acc parallel loop collapse(3) default(present) async(1)
       do k=1,nn
@@ -523,14 +594,22 @@ module mod_solver_gpu
         end do
       end do
     else
+#if !defined(_USE_DIEZDECOMP)
       !$acc host_data use_device(aa_y,cc_y,aa_z,cc_z,work)
+#endif
       istat = cudecompTransposeYtoZ(ch,gd_ptdma,aa_y,aa_z,work,dtype_rp,stream=istream)
       istat = cudecompTransposeYtoZ(ch,gd_ptdma,cc_y,cc_z,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
       !$acc end host_data
+#endif
     end if
+#if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_y,pp_z,work)
+#endif
     istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
+#endif
     !
     ! solve reduced systems
     !
@@ -596,9 +675,13 @@ module mod_solver_gpu
     !
     ! transpose solution to the original z-distributed form
     !
+#if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_z,pp_y,work)
+#endif
     istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
+#endif
     !
     ! obtain final solution on the inner points
     !
@@ -797,10 +880,20 @@ module mod_solver_gpu
       end do
     end do
     !
+#if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_x,pp_y,pp_z,work)
-    istat = cudecompTransposeXtoY(ch,gd_ptdma,pp_x,pp_y,work,dtype_rp,stream=istream)
-    istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+#endif
+    if(.not.is_diezdecomp_x2z_z2x_transposes) then
+      istat = cudecompTransposeXtoY(ch,gd_ptdma,pp_x,pp_y,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+    else
+#if defined(_USE_DIEZDECOMP)
+      istat = diezdecompTransposeXtoZ(ch,gd_ptdma,pp_x,pp_z,work,dtype_rp,stream=istream)
+#endif
+    end if
+#if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
+#endif
     !
     !$acc parallel loop gang vector collapse(2) default(present) async(1)
     do j=1,ny_r
@@ -832,10 +925,20 @@ module mod_solver_gpu
       end do
     end if
     !
+#if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_z,pp_y,pp_x,work)
-    istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
-    istat = cudecompTransposeYtoX(ch,gd_ptdma,pp_y,pp_x,work,dtype_rp,stream=istream)
+#endif
+    if(.not.is_diezdecomp_x2z_z2x_transposes) then
+      istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoX(ch,gd_ptdma,pp_y,pp_x,work,dtype_rp,stream=istream)
+    else
+#if defined(_USE_DIEZDECOMP)
+      istat = diezdecompTransposeZtoX(ch,gd_ptdma,pp_z,pp_x,work,dtype_rp,stream=istream)
+#endif
+    end if
+#if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
+#endif
     !
     !$acc parallel loop gang vector collapse(2) default(present) async(1)
     do j=1,ny
@@ -854,6 +957,7 @@ module mod_solver_gpu
       end do
     end do
   end subroutine gaussel_ptdma_gpu_fast_1d
+  !
   subroutine solver_gaussel_z_gpu(n,ng,hi,a,b,c,bcz,c_or_f,norm,p)
     use mod_param, only: eps
     implicit none
@@ -907,10 +1011,20 @@ module mod_solver_gpu
               end do
             end do
           end do
+#if !defined(_USE_DIEZDECOMP)
           !$acc host_data use_device(px,py,pz,work)
-          istat = cudecompTransposeXtoY(ch,gd,px,py,work,dtype_rp,stream=istream)
-          istat = cudecompTransposeYtoZ(ch,gd,py,pz,work,dtype_rp,stream=istream)
+#endif
+          if(.not.is_diezdecomp_x2z_z2x_transposes) then
+            istat = cudecompTransposeXtoY(ch,gd,px,py,work,dtype_rp,stream=istream)
+            istat = cudecompTransposeYtoZ(ch,gd,py,pz,work,dtype_rp,stream=istream)
+          else
+#if defined(_USE_DIEZDECOMP)
+            istat = diezdecompTransposeXtoZ(ch,gd,px,pz,work,dtype_rp,stream=istream)
+#endif
+          end if
+#if !defined(_USE_DIEZDECOMP)
           !$acc end host_data
+#endif
         case(2)
           !
           ! transpose p -> py to axis-contiguous layout
@@ -924,9 +1038,13 @@ module mod_solver_gpu
               end do
             end do
           end do
+#if !defined(_USE_DIEZDECOMP)
           !$acc host_data use_device(py,pz,work)
+#endif
           istat = cudecompTransposeYtoZ(ch,gd,py,pz,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
           !$acc end host_data
+#endif
         case(3)
         end select
       end if
@@ -947,10 +1065,20 @@ module mod_solver_gpu
     if(.not.is_poisson_pcr_tdma .and. .not.is_no_decomp_z) then
       select case(ipencil_axis)
       case(1)
+#if !defined(_USE_DIEZDECOMP)
         !$acc host_data use_device(pz,py,px,work)
-        istat = cudecompTransposeZtoY(ch,gd,pz,py,work,dtype_rp,stream=istream)
-        istat = cudecompTransposeYtoX(ch,gd,py,px,work,dtype_rp,stream=istream)
+#endif
+        if(.not.is_diezdecomp_x2z_z2x_transposes) then
+          istat = cudecompTransposeZtoY(ch,gd,pz,py,work,dtype_rp,stream=istream)
+          istat = cudecompTransposeYtoX(ch,gd,py,px,work,dtype_rp,stream=istream)
+        else
+#if defined(_USE_DIEZDECOMP)
+          istat = diezdecompTransposeZtoX(ch,gd,pz,px,work,dtype_rp,stream=istream)
+#endif
+        end if
+#if !defined(_USE_DIEZDECOMP)
         !$acc end host_data
+#endif
         !$acc parallel loop collapse(3) default(present) async(1)
         !$OMP parallel do   collapse(3) DEFAULT(shared)
         do k=1,n(3)
@@ -961,9 +1089,13 @@ module mod_solver_gpu
           end do
         end do
       case(2)
+#if !defined(_USE_DIEZDECOMP)
         !$acc host_data use_device(pz,py,work)
+#endif
         istat = cudecompTransposeZtoY(ch,gd,pz,py,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
         !$acc end host_data
+#endif
         !
         ! transpose py -> p to default layout
         !
@@ -1079,11 +1211,15 @@ module mod_solver_gpu
         end do
       end do
       !
+#if !defined(_USE_DIEZDECOMP)
       !$acc host_data use_device(aa_y,bb_y,cc_y,aa_z,bb_z,cc_z,work)
+#endif
       istat = cudecompTransposeYtoZ(ch,gd_ptdma,aa_y,aa_z,work,dtype_rp,stream=istream)
       istat = cudecompTransposeYtoZ(ch,gd_ptdma,bb_y,bb_z,work,dtype_rp,stream=istream)
       istat = cudecompTransposeYtoZ(ch,gd_ptdma,cc_y,cc_z,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
       !$acc end host_data
+#endif
       !
       if(is_periodic) then
         !$acc parallel loop collapse(3) default(present) async(1)
@@ -1167,9 +1303,13 @@ module mod_solver_gpu
       end do
     end do
     !
+#if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_y,pp_z,work)
+#endif
     istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
+#endif
     !
     !$acc parallel loop gang vector collapse(2) default(present) async(1)
     do j=1,ny_r
@@ -1201,9 +1341,13 @@ module mod_solver_gpu
       end do
     end if
     !
+#if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_z,pp_y,work)
+#endif
     istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
+#if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
+#endif
     !
     !$acc parallel loop gang vector collapse(2) default(present) async(1)
     do j=1,ny


### PR DESCRIPTION
This PR wraps up the major effort by Rafael Diez, @Rafael10Diez, to port CaNS to run on Cray-AMD-based hardware like the LUMI supercomputer in Finland.

To achieve this, some design decisions had to be made, e.g., modify the cuDecomp library to build and run on AMD hardware, leveraging some of C++'s portability features, or writing something equivalent in Fortran + OpenACC for a simpler build workflow and easier control of the features? At the end, Rafael ended up deciding for the latter option and wrote [diezDecomp](https://github.com/Rafael10Diez/diezDecomp), which in addition to the basic transpose/halo exchange operations also performs transposes "_from any to any_" chosen decomposition (e.g., allowing for a slab-to-pencils data redistribution, or a direct X-to-Z/Z-to-X transpose (which is already exercised in this PR).

Apart from this, the remainder of the port used HIP for the FFTs, via the [hipfort](https://github.com/ROCm/hipfort) bindings, and OpenACC. This enables running on LUMI, thanks to the Cray/HPE compiler supporting OpenACC.

To summarize, this PR:

 - Enables support for running on supercomputers like LUMI/Frontier using the Cray/HPE compiler
 - Used [hipfort](https://github.com/ROCm/hipfort) for the FFTs implementation
 - Used [diezDecomp](https://github.com/Rafael10Diez/diezDecomp) as portable/versatile domain decomposition library written in Fortran+OpenACC
 
An earlier version of the code was used to produce the results of this paper: R. Diez, J. Peeters & P. Costa. "_A pencil-distributed finite-difference solver for extreme-scale calculations of turbulent wall flows at high Reynolds number_". Accepted for Publication in Computer Physics Communications [arxiv.org/abs/2502.06296](https://arxiv.org/abs/2502.06296).

Thanks, Rafael @Rafael10Diez, for the big effort and contribution :tada:!!